### PR TITLE
docs(physics): Rapier2D物理設定のドキュメント追加

### DIFF
--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -19,6 +19,9 @@ fn main() {
             ..default()
         }))
         // External plugins
+        // Rapier physics with 100 pixels per meter scaling
+        // Default gravity is -9.81 m/s², which equals -981 pixels/s²
+        // This is approximately our target of -980 pixels/s² from constants::physics::GRAVITY
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugins(RapierDebugRenderPlugin::default()) // Debug rendering
         .add_plugins(AudioPlugin)


### PR DESCRIPTION
## 概要
Rapier2D物理エンジンの設定に関する説明コメントを追加しました。実装は既に完了していましたが、重力のスケーリング計算について明確な説明が不足していたため、コメントを追加して理解しやすくしました。

## 変更内容
- **重力計算の説明コメント追加**
  - Rapierのデフォルト重力: -9.81 m/s²
  - スケーリング係数: 100 pixels/meter
  - 実効重力: -981 pixels/s² ≈ -980 pixels/s² (目標値)
- **既存実装の確認**
  - RapierPhysicsPlugin, RapierDebugRenderPlugin は既に正しく設定済み
  - pixels_per_meter(100.0) も適切に設定済み

## テスト
- [x] `cargo build -p suika-game` 成功
- [x] `cargo clippy -p suika-game` 実行済み（警告なし）
- [x] `cargo fmt` 実行済み

## 備考
このissueは実質的に既に完了していました。今回はドキュメントの改善のみです。

Closes #16