### PR TITLE
feat(core): デバッグレンダラーのトグル機能を追加

### DIFF
--- a/app/suika-game/src/debug.rs
+++ b/app/suika-game/src/debug.rs
@@ -1,0 +1,110 @@
+//! Debug rendering and visualization tools
+//!
+//! This module provides debug visualization features for development,
+//! including physics collider rendering that can be toggled at runtime.
+//!
+//! Debug features are only enabled in debug builds and are automatically
+//! stripped from release builds.
+
+use bevy::prelude::*;
+
+/// Debug plugin for development tools and visualizations
+///
+/// This plugin adds debug rendering capabilities including:
+/// - Physics collider visualization
+/// - Toggle debug rendering with the D key
+///
+/// # Debug Builds Only
+///
+/// All debug features are conditionally compiled and only available
+/// in debug builds (`#[cfg(debug_assertions)]`). They are completely
+/// removed from release builds.
+pub struct DebugPlugin;
+
+impl Plugin for DebugPlugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(debug_assertions)]
+        {
+            use bevy_rapier2d::render::RapierDebugRenderPlugin;
+
+            info!("Debug mode enabled - press D to toggle physics debug rendering");
+
+            // Add Rapier debug renderer
+            app.add_plugins(RapierDebugRenderPlugin::default());
+
+            // Add debug toggle system
+            app.add_systems(Update, toggle_debug_render);
+        }
+
+        #[cfg(not(debug_assertions))]
+        {
+            // In release builds, this plugin does nothing
+            info!("Release mode - debug rendering disabled");
+        }
+    }
+}
+
+/// Toggles physics debug rendering on/off with the D key
+///
+/// This system listens for the D key press and toggles the visibility
+/// of physics colliders and other Rapier debug information.
+///
+/// # Controls
+///
+/// - `D` key: Toggle debug rendering on/off
+#[cfg(debug_assertions)]
+fn toggle_debug_render(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut debug_render: ResMut<bevy_rapier2d::render::DebugRenderContext>,
+) {
+    if keyboard.just_pressed(KeyCode::KeyD) {
+        debug_render.enabled = !debug_render.enabled;
+
+        let status = if debug_render.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        };
+
+        info!("Debug rendering {}", status);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_debug_plugin_builds() {
+        // Test that the plugin can be constructed
+        let plugin = DebugPlugin;
+
+        // Verify the plugin type is correct
+        assert_eq!(
+            std::any::type_name::<DebugPlugin>(),
+            std::any::type_name_of_val(&plugin)
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_debug_mode_enabled() {
+        // In debug builds, debug assertions should be enabled
+        let debug_enabled = cfg!(debug_assertions);
+        assert!(
+            debug_enabled,
+            "Debug mode should be enabled in debug builds"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn test_debug_mode_disabled() {
+        // In release builds, debug assertions should be disabled
+        let debug_enabled = cfg!(debug_assertions);
+        assert!(
+            !debug_enabled,
+            "Debug mode should be disabled in release builds"
+        );
+    }
+}

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -1,5 +1,6 @@
 mod camera;
 mod container;
+mod debug;
 
 use bevy::prelude::*;
 use bevy_kira_audio::AudioPlugin;
@@ -7,6 +8,7 @@ use bevy_rapier2d::prelude::*;
 
 use camera::setup_camera;
 use container::setup_container;
+use debug::DebugPlugin;
 use suika_game_assets::GameAssetsPlugin;
 use suika_game_audio::GameAudioPlugin;
 use suika_game_core::prelude::*;
@@ -28,7 +30,6 @@ fn main() {
         // Default gravity is -9.81 m/s², which equals -981 pixels/s²
         // This is approximately our target of -980 pixels/s² from constants::physics::GRAVITY
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-        .add_plugins(RapierDebugRenderPlugin::default()) // Debug rendering
         .add_plugins(AudioPlugin)
         // Application state
         .init_state::<AppState>()
@@ -42,6 +43,8 @@ fn main() {
         .add_plugins(GameCorePlugin)
         .add_plugins(GameUIPlugin)
         .add_plugins(GameAudioPlugin)
+        // Debug plugin (debug builds only)
+        .add_plugins(DebugPlugin)
         // Startup systems
         .add_systems(
             Startup,


### PR DESCRIPTION
## 概要
Issue #20 の実装。物理コライダーを可視化するデバッグレンダラーを設定し、Dキーでのトグル機能を実装しました。

## 変更内容
- `app/suika-game/src/debug.rs` を新規作成
  - `DebugPlugin` を実装
  - デバッグビルド時のみ有効（`#[cfg(debug_assertions)]`）
  - `RapierDebugRenderPlugin` を追加
  - Dキーでのトグル機能を実装
- `main.rs` を更新
  - 直接的な `RapierDebugRenderPlugin` 追加を削除
  - `DebugPlugin` を追加

## 機能
- **Dキー**: 物理デバッグレンダリングのON/OFF切り替え
- **デバッグビルド専用**: リリースビルドでは完全に除外
- **デフォルト有効**: デバッグビルド起動時は自動的に有効
- **コライダー可視化**: Rapierのデフォルト色（緑色の線）で表示
- **ログ出力**: デバッグ状態変更時に情報ログを出力

## 追加テスト
- `test_debug_plugin_builds`: プラグインが正しく構築されることを確認
- `test_debug_mode_enabled`: デバッグビルドでデバッグモードが有効であることを確認

## テスト結果
- [x] ユニットテスト追加/更新（2つの新規テスト、すべてパス）
- [x] `just check` 実行済み（fmt, clippy, test, build すべて成功）
- [ ] ゲーム内で動作確認（次のフェーズで確認予定）

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added physics debug visualization toggle accessible via the D key for development debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->