### PR TITLE
feat(physics): 物理パラメータの調整（jiggle effect実装）

### DIFF
--- a/app/core/src/systems/input.rs
+++ b/app/core/src/systems/input.rs
@@ -228,7 +228,10 @@ pub fn handle_fruit_drop_input(
                 commands.entity(entity).insert((
                     RigidBody::Dynamic,
                     Velocity::zero(), // Reset velocity to drop straight down
-                    Restitution::coefficient(0.0), // No bounce
+                    Restitution {
+                        coefficient: params.restitution,
+                        combine_rule: CoefficientCombineRule::Min, // Use minimum restitution in collisions
+                    },
                     Friction::coefficient(params.friction),
                     ColliderMassProperties::Mass(params.mass),
                     Damping {


### PR DESCRIPTION
## 概要
本家スイカゲームの物理挙動を再現するため、反発係数を調整しました。フルーツ同士の衝突ではバウンスし、地面との衝突ではバウンスしない自然な動きを実装しました。

## 変更内容
- 反発係数の組み合わせルールを `Min`（最小値）に変更
- フルーツの反発係数を自然な値に設定（0.2-0.3、サイズ別）
- 地面の反発係数を 0.0 に設定（バウンスなし）
- これにより、min(フルーツ, 地面) = 0、min(フルーツ, フルーツ) > 0 を実現

## 物理挙動
| 衝突の種類 | 反発係数の計算 | 結果 |
|-----------|--------------|------|
| 地面に着地 | min(0.3, 0.0) = 0.0 | バウンスなし |
| フルーツ同士 | min(0.3, 0.25) = 0.25 | バウンスする |
| 壁に当たる | min(0.3, 0.3) = 0.3 | 少し弾む |

## フルーツごとの反発係数
- 小（チェリー、イチゴ、ブドウ）: 0.3
- 中（デコポン、柿、リンゴ、梨）: 0.25
- 大（桃、パイナップル、メロン、スイカ）: 0.2

## テスト
- [x] 全テスト通過（77テスト）
- [x] `cargo clippy` 実行済み（警告なし）
- [x] ゲーム内で動作確認済み
- [x] 本家スイカゲームの挙動と一致確認

Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fruit drop physics to use dynamic bounce properties based on fruit characteristics
  * Refined container wall collision behavior: side walls now bounce while the bottom wall remains stationary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->