### PR TITLE
refactor(core): GameCorePluginでリソース初期化を一元管理

### DIFF
--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -128,18 +128,27 @@ impl Plugin for GameCorePlugin {
     fn build(&self, app: &mut App) {
         info!("GameCorePlugin initialized");
 
+        // Initialize application state
+        app.init_state::<states::AppState>();
+
+        // Initialize game resources
+        app.init_resource::<resources::GameState>()
+            .init_resource::<resources::ComboTimer>()
+            .init_resource::<resources::GameOverTimer>()
+            .init_resource::<resources::NextFruitType>()
+            .init_resource::<systems::input::SpawnPosition>()
+            .init_resource::<systems::input::InputMode>()
+            .init_resource::<systems::input::LastCursorPosition>();
+
         // Register events (Phase 5+)
         app.add_message::<events::FruitMergeEvent>();
 
-        // TODO: Phase 3+ - Register systems and resources
-        // app
-        //     .init_state::<AppState>()
-        //     .init_resource::<GameState>()
-        //     .init_resource::<ComboTimer>()
-        //     .init_resource::<GameOverTimer>()
-        //     .init_resource::<NextFruitType>()
-        //     .add_systems(Startup, setup_systems)
-        //     .add_systems(Update, game_systems);
+        // TODO: Phase 5+ - Register collision and merge systems
+        // app.add_systems(Update, (
+        //     collision::detect_fruit_collision,
+        //     collision::handle_fruit_merge,
+        //     score::update_score_on_merge,
+        // ));
     }
 }
 
@@ -150,6 +159,10 @@ mod tests {
     #[test]
     fn test_plugin_builds() {
         let mut app = App::new();
+        // MinimalPlugins + StatesPlugin are required for GameCorePlugin
+        // (StatesPlugin is needed for init_state, included in DefaultPlugins but not MinimalPlugins)
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(bevy::state::app::StatesPlugin);
         app.add_plugins(GameCorePlugin);
         // Plugin should build without panicking
     }

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -35,17 +35,8 @@ fn main() {
         // This is approximately our target of -980 pixels/s² (configurable in physics.ron)
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugins(AudioPlugin)
-        // Application state
-        .init_state::<AppState>()
-        // Game resources
-        .init_resource::<GameState>()
-        .init_resource::<ComboTimer>()
-        .init_resource::<GameOverTimer>()
-        .init_resource::<NextFruitType>()
-        .init_resource::<SpawnPosition>()
-        .init_resource::<InputMode>()
-        .init_resource::<LastCursorPosition>()
         // Game plugins (internal crates)
+        // Note: GameCorePlugin initializes AppState and all game resources
         .add_plugins(GameAssetsPlugin) // Load assets first
         .add_plugins(GameConfigPlugin) // Load game configuration
         .add_plugins(GameCorePlugin)


### PR DESCRIPTION
## 概要
main.rsで個別に行っていたリソース初期化をGameCorePluginに集約しました。これによりプラグインが自己完結し、main.rsはアプリ構成のみを担当します。

## 変更内容
- `GameCorePlugin::build()` で以下を初期化：
  - `AppState`（init_state）
  - `GameState`, `ComboTimer`, `GameOverTimer`, `NextFruitType`
  - `SpawnPosition`, `InputMode`, `LastCursorPosition`
- `main.rs` から該当する初期化コードを削除
- `test_plugin_builds` に `StatesPlugin` を追加（init_state に必要）

## テスト
- [x] 全テスト: 72 unit tests + 11 doctests passed
- [x] Clippy: No warnings
- [x] Build: Success

## 技術詳細
`init_state::<AppState>()` は `StatesPlugin`（`DefaultPlugins` に含まれる）が必要なため、テストで `bevy::state::app::StatesPlugin` を明示的に追加。

Closes #101