### PR TITLE
feat(core): Phase 6 ゲームオーバー検出の実装

### DIFF
--- a/app/core/src/systems/boundary.rs
+++ b/app/core/src/systems/boundary.rs
@@ -1,0 +1,132 @@
+//! Boundary overflow detection and game-over warning effects
+//!
+//! This module monitors whether any fruit has risen above the boundary line.
+//! When fruits stay above the line long enough, the game transitions to
+//! `AppState::GameOver`.  While in warning state the boundary line sprite
+//! blinks red to alert the player.
+
+use bevy::prelude::*;
+
+use crate::components::{BoundaryLine, Fruit};
+use crate::config::{PhysicsConfig, PhysicsConfigHandle};
+use crate::resources::GameOverTimer;
+use crate::states::AppState;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Returns the boundary-line Y threshold from config, falling back to the
+/// physics.ron default when the asset is not yet loaded.
+fn boundary_y(
+    physics_handle: Option<&Res<PhysicsConfigHandle>>,
+    physics_assets: Option<&Res<Assets<PhysicsConfig>>>,
+) -> f32 {
+    physics_handle
+        .and_then(|h| physics_assets.and_then(|a| a.get(&h.0)))
+        .map(|c| c.boundary_line_y)
+        .unwrap_or(300.0)
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Checks whether any fruit is above the boundary line and updates the timer.
+///
+/// - If at least one fruit is above the line, the `GameOverTimer` advances and
+///   the warning flag is set.
+/// - If no fruits are above the line, the timer and warning flag are reset.
+///
+/// The boundary Y position is read from `PhysicsConfig`; the default 300.0 is
+/// used while the asset loads.
+pub fn check_boundary_overflow(
+    fruit_query: Query<&Transform, With<Fruit>>,
+    mut game_over_timer: ResMut<GameOverTimer>,
+    time: Res<Time>,
+    physics_handle: Option<Res<PhysicsConfigHandle>>,
+    physics_assets: Option<Res<Assets<PhysicsConfig>>>,
+) {
+    let threshold = boundary_y(physics_handle.as_ref(), physics_assets.as_ref());
+
+    let any_overflow = fruit_query.iter().any(|t| t.translation.y > threshold);
+
+    if any_overflow {
+        game_over_timer.tick_warning(time.delta_secs());
+    } else {
+        game_over_timer.reset();
+    }
+}
+
+/// Transitions to `AppState::GameOver` when the timer exceeds its threshold.
+///
+/// Only fires from `AppState::Playing` and guards against double-triggering.
+pub fn trigger_game_over(
+    game_over_timer: Res<GameOverTimer>,
+    current_state: Res<State<AppState>>,
+    mut next_state: ResMut<NextState<AppState>>,
+) {
+    if *current_state.get() != AppState::Playing {
+        return;
+    }
+
+    if game_over_timer.is_game_over() {
+        info!(
+            "Game Over! Fruit exceeded boundary for {:.2}s",
+            game_over_timer.time_over_boundary
+        );
+        next_state.set(AppState::GameOver);
+    }
+}
+
+/// Animates the boundary line sprite to blink red while in warning state.
+///
+/// - Warning active: alternates between bright and dark red at ~2 Hz
+/// - Warning inactive: restores the default semi-transparent red color
+pub fn animate_boundary_warning(
+    game_over_timer: Res<GameOverTimer>,
+    mut boundary_query: Query<&mut Sprite, With<BoundaryLine>>,
+    time: Res<Time>,
+) {
+    for mut sprite in boundary_query.iter_mut() {
+        if game_over_timer.is_warning {
+            // Smooth sine-based blink at ~2 Hz (visible even at low frame rates)
+            let blink = (time.elapsed_secs() * 4.0).sin();
+            let alpha = 0.4 + 0.4 * blink; // range [0.0, 0.8]
+            sprite.color = Color::srgba(1.0, 0.0, 0.0, alpha);
+        } else {
+            // Default: semi-transparent red
+            sprite.color = Color::srgba(1.0, 0.0, 0.0, 0.5);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_game_over_timer_triggers_at_threshold() {
+        let mut timer = GameOverTimer::default();
+        assert!(!timer.is_game_over());
+
+        timer.tick_warning(3.0);
+        assert!(timer.is_game_over());
+    }
+
+    #[test]
+    fn test_game_over_timer_resets() {
+        let mut timer = GameOverTimer::default();
+        timer.tick_warning(2.0);
+        assert!(timer.is_warning);
+
+        timer.reset();
+        assert!(!timer.is_warning);
+        assert_eq!(timer.time_over_boundary, 0.0);
+        assert!(!timer.is_game_over());
+    }
+}

--- a/app/core/src/systems/game_over.rs
+++ b/app/core/src/systems/game_over.rs
@@ -1,0 +1,130 @@
+//! Game-over and game-reset systems
+//!
+//! This module provides two lifecycle systems:
+//!
+//! - `save_highscore_on_game_over` — runs on `OnEnter(AppState::GameOver)`.
+//!   Compares the current score with the stored highscore and writes to disk
+//!   when a new record is set.
+//!
+//! - `reset_game_state` — runs on `OnEnter(AppState::Playing)`.
+//!   Clears all in-game resources and despawns existing fruits so each new
+//!   game starts from a clean slate.  The highscore is intentionally preserved.
+
+use bevy::prelude::*;
+
+use crate::components::Fruit;
+use crate::constants::storage::SAVE_DIR;
+use crate::persistence::{HighscoreData, save_highscore};
+use crate::resources::{ComboTimer, GameOverTimer, GameState};
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Saves the highscore to disk when the game ends.
+///
+/// Only writes to disk when the current score exceeds the stored highscore.
+/// Runs once on `OnEnter(AppState::GameOver)`.
+pub fn save_highscore_on_game_over(mut game_state: ResMut<GameState>) {
+    if game_state.score > game_state.highscore {
+        info!(
+            "New highscore! {} → {}",
+            game_state.highscore, game_state.score
+        );
+        game_state.highscore = game_state.score;
+
+        let data = HighscoreData {
+            highscore: game_state.highscore,
+        };
+
+        match save_highscore(&data, std::path::Path::new(SAVE_DIR)) {
+            Ok(_) => info!("Highscore saved to {SAVE_DIR}/highscore.json"),
+            Err(e) => error!("Failed to save highscore: {e}"),
+        }
+    } else {
+        info!(
+            "Game over. Score: {} (Highscore: {})",
+            game_state.score, game_state.highscore
+        );
+    }
+}
+
+/// Resets all mutable game state and despawns existing fruits.
+///
+/// Runs once on `OnEnter(AppState::Playing)` so that both the initial game
+/// start and any subsequent retries begin from a consistent state.
+///
+/// The highscore is **not** reset.
+pub fn reset_game_state(
+    mut commands: Commands,
+    mut game_state: ResMut<GameState>,
+    mut combo_timer: ResMut<ComboTimer>,
+    mut game_over_timer: ResMut<GameOverTimer>,
+    fruit_query: Query<Entity, With<Fruit>>,
+) {
+    let highscore = game_state.highscore;
+
+    *game_state = GameState {
+        score: 0,
+        highscore,
+        elapsed_time: 0.0,
+    };
+    *combo_timer = ComboTimer::default();
+    *game_over_timer = GameOverTimer::default();
+
+    let mut despawned = 0u32;
+    for entity in fruit_query.iter() {
+        commands.entity(entity).despawn();
+        despawned += 1;
+    }
+
+    info!("Game reset. Highscore: {highscore}. Despawned {despawned} fruits.");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_game_state_reset_preserves_highscore() {
+        let mut state = GameState {
+            score: 5000,
+            highscore: 8000,
+            elapsed_time: 42.0,
+        };
+
+        let highscore = state.highscore;
+        state = GameState {
+            score: 0,
+            highscore,
+            elapsed_time: 0.0,
+        };
+
+        assert_eq!(state.score, 0);
+        assert_eq!(state.highscore, 8000);
+        assert_eq!(state.elapsed_time, 0.0);
+    }
+
+    #[test]
+    fn test_highscore_only_updated_when_beaten() {
+        let score = 5000u32;
+        let highscore = 8000u32;
+
+        // Score did not beat highscore
+        let new_highscore = if score > highscore { score } else { highscore };
+        assert_eq!(new_highscore, 8000);
+
+        // Score beats highscore
+        let score2 = 10000u32;
+        let new_highscore2 = if score2 > highscore {
+            score2
+        } else {
+            highscore
+        };
+        assert_eq!(new_highscore2, 10000);
+    }
+}

--- a/app/core/src/systems/mod.rs
+++ b/app/core/src/systems/mod.rs
@@ -3,8 +3,10 @@
 //! This module contains the core game systems that implement game logic,
 //! physics, and gameplay mechanics using Bevy's ECS (Entity-Component-System).
 
+pub mod boundary;
 pub mod collision;
 pub mod effects;
+pub mod game_over;
 pub mod input;
 pub mod merge;
 pub mod preview;


### PR DESCRIPTION
## 概要
フルーツが境界線を超えた際のゲームオーバー検出システムを実装した。
境界線超過が3秒継続するとPlaying→GameOver状態へ遷移し、ハイスコアを保存する。
新ゲーム開始時はスコア・タイマー・フルーツをリセットし、ハイスコアは保持する。

## 変更内容
- `systems/boundary.rs` 追加: 境界線超過チェック・ゲームオーバー遷移・警告点滅アニメーション
- `systems/game_over.rs` 追加: ゲームオーバー時ハイスコア保存・Playing入場時ゲームリセット
- `systems/mod.rs`: `boundary` / `game_over` モジュール登録
- `lib.rs`: Phase 6 全システムを `GameCorePlugin` に統合

## テスト
- [x] ユニットテスト追加 (123テスト / 0失敗)
- [x] `cargo clippy --workspace -- -D warnings` パス
- [x] `cargo test --workspace` パス
- [x] `cargo build --workspace` パス

Closes #34