### PR TITLE
fix(core): ゲームオーバー検出と境界線位置の修正 (Issue #34)

### DIFF
--- a/app/core/src/resources.rs
+++ b/app/core/src/resources.rs
@@ -118,8 +118,10 @@ impl Default for GameOverTimer {
     fn default() -> Self {
         Self {
             time_over_boundary: 0.0,
-            // Default game over timer (loaded from game_rules.ron at runtime)
-            warning_threshold: 3.0,
+            // Short threshold: long enough to ignore newly dropped fruits
+            // passing through the boundary area, fast enough to feel immediate.
+            // Can be overridden from game_rules.ron at runtime.
+            warning_threshold: 0.5,
             is_warning: false,
         }
     }
@@ -271,7 +273,7 @@ mod tests {
     fn test_game_over_timer_default() {
         let timer = GameOverTimer::default();
         assert_eq!(timer.time_over_boundary, 0.0);
-        assert_eq!(timer.warning_threshold, 3.0); // Default value
+        assert_eq!(timer.warning_threshold, 0.5); // Short threshold for near-immediate game-over
         assert!(!timer.is_warning);
         assert!(!timer.is_game_over());
     }
@@ -281,18 +283,18 @@ mod tests {
         let mut timer = GameOverTimer::default();
 
         // Start warning
-        timer.tick_warning(1.0);
+        timer.tick_warning(0.2);
         assert!(timer.is_warning);
         assert!(!timer.is_game_over());
-        assert_eq!(timer.warning_progress(), 1.0 / 3.0);
+        assert_eq!(timer.warning_progress(), 0.2 / 0.5);
 
-        // Continue warning
-        timer.tick_warning(1.0);
-        assert_eq!(timer.time_over_boundary, 2.0);
+        // Continue warning — still below threshold
+        timer.tick_warning(0.2);
+        assert_eq!(timer.time_over_boundary, 0.4);
         assert!(!timer.is_game_over());
 
         // Reach game over
-        timer.tick_warning(1.5);
+        timer.tick_warning(0.2);
         assert!(timer.is_game_over());
         assert_eq!(timer.warning_progress(), 1.0);
 

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -52,7 +52,10 @@ fn main() {
                 setup_container,
                 load_highscore_system,
                 setup_fruit_preview,
-                spawn_held_fruit,
+                // Immediately transition to Playing so Phase 6 boundary/game-over
+                // systems (gated to AppState::Playing) begin running.
+                // Phase 7 will replace this with a proper title screen flow.
+                start_playing,
             ),
         )
         // Update systems (run every frame)
@@ -67,6 +70,16 @@ fn main() {
             ),
         )
         .run();
+}
+
+/// Immediately transitions to `AppState::Playing` on game start.
+///
+/// This is a temporary measure until Phase 7 implements the title screen.
+/// Without it the game stays in `AppState::Title` and the Phase 6 boundary /
+/// game-over systems (which are gated to `Playing`) never run.
+fn start_playing(mut next_state: ResMut<NextState<AppState>>) {
+    next_state.set(AppState::Playing);
+    info!("Starting game directly in Playing state (Phase 7 will add title screen)");
 }
 
 /// Loads the highscore from disk at startup


### PR DESCRIPTION
## 概要

Issue #34（Phase 6 ゲームオーバー検出）の実装後に発見されたバグを修正。境界線の位置が `physics.ron` の設定を反映しない問題、および `Falling` 状態フルーツが検出されない問題を解消。

## 変更内容

- **境界線位置の修正**: `setup_container` が Startup 時に fallback 値(y=300)で境界線を生成後、`hot_reload_physics_config` が `BoundaryLine` エンティティを更新しなかった。`AssetEvent::Added`（初回ロード）と `AssetEvent::Modified`（ホットリロード）の両方で Transform を更新するよう修正
- **クエリ競合の解消**: `&mut Transform` を持つ2つのクエリの競合を `Without<BoundaryLine>` / `Without<Container>` / `Without<Fruit>` フィルターで明示的に解消
- **オーバーフロー検出の修正**: フィルターを `== Landed` から `!= Held` に変更。マージ生成フルーツなど `Falling` 状態のまま境界線上に留まるケースを検出できるよう対応。タイマーを 3.0s → 0.5s に短縮し、ドロップ直後のフルーツが境界線を通過する際の誤検知を防止
- **ログ整理**: 毎フレーム出力されていた `overflow!` / `cleared` ログを削除。ゲームオーバー時のみログを出力
- **AppState 修正**: `start_playing()` 起動システムを追加し、Phase 7 タイトル画面実装まで即座に `Playing` 状態へ遷移

## テスト

- [x] ユニットテスト更新（`warning_threshold` 変更に合わせてテスト値修正）
- [x] ゲーム内で動作確認（フルーツが境界線を超えると 0.5s 後にゲームオーバー）
- [x] `cargo test --workspace` 全パス（144テスト）
- [x] `cargo clippy --workspace -- -D warnings` 警告なし

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Game now launches directly in playing mode, bypassing the title screen.

* **Bug Fixes**
  * Held fruits are no longer counted in boundary overflow detection.
  * Game over warning now triggers at a faster rate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->