### PR TITLE
feat(core): Loadingステートを追加してRON設定ファイルを確実にロードしてから起動

### DIFF
--- a/app/core/src/states.rs
+++ b/app/core/src/states.rs
@@ -13,6 +13,7 @@ use bevy::prelude::*;
 ///
 /// # State Transitions
 ///
+/// - `Loading` → `Title`: All required RON configs have finished loading
 /// - `Title` → `Playing`: Player starts a new game
 /// - `Playing` → `Paused`: Player pauses the game
 /// - `Paused` → `Playing`: Player resumes the game
@@ -39,11 +40,18 @@ use bevy::prelude::*;
 /// ```
 #[derive(States, Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum AppState {
+    /// Asset loading state
+    ///
+    /// The application waits here until all required RON config files have
+    /// finished loading.  Once ready, automatically transitions to `Title`.
+    /// The game world (container walls, etc.) is set up on exit from this
+    /// state so it always uses the values from the config files.
+    #[default]
+    Loading,
+
     /// Title screen state
     ///
     /// Displays the game title, menu options, and high score.
-    /// This is the initial state when the application starts.
-    #[default]
     Title,
 
     /// Active gameplay state
@@ -72,7 +80,7 @@ mod tests {
     #[test]
     fn test_app_state_default() {
         let state = AppState::default();
-        assert_eq!(state, AppState::Title);
+        assert_eq!(state, AppState::Loading);
     }
 
     #[test]
@@ -110,6 +118,7 @@ mod tests {
     fn test_app_state_all_variants() {
         // Ensure all variants are covered
         let states = vec![
+            AppState::Loading,
             AppState::Title,
             AppState::Playing,
             AppState::Paused,

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -44,10 +44,9 @@ fn main() {
         // Debug plugin (debug builds only)
         .add_plugins(DebugPlugin)
         // Startup systems
-        .add_systems(
-            Startup,
-            (setup_camera, setup_container, load_highscore_system),
-        )
+        .add_systems(Startup, (setup_camera, load_highscore_system))
+        // setup_container runs on exit from Loading so physics.ron is guaranteed loaded
+        .add_systems(OnExit(AppState::Loading), setup_container)
         // Gameplay systems — only run while actively playing
         .add_systems(
             Update,

--- a/app/suika-game/tests/integration_test.rs
+++ b/app/suika-game/tests/integration_test.rs
@@ -60,13 +60,14 @@ fn test_app_state_definitions() {
     use suika_game_core::prelude::*;
 
     // Test that all app states are defined correctly
+    let _loading = AppState::Loading;
     let _title = AppState::Title;
     let _playing = AppState::Playing;
     let _paused = AppState::Paused;
     let _game_over = AppState::GameOver;
 
-    // Verify default state
-    assert_eq!(AppState::default(), AppState::Title);
+    // Verify default state (Loading is the initial state so configs load first)
+    assert_eq!(AppState::default(), AppState::Loading);
 }
 
 #[test]


### PR DESCRIPTION
## 概要

`AppState::Loading` を初期ステートとして追加し、全6つのRON設定ファイルが完全にロードされてから `AppState::Title` に遷移するようにした。これにより `setup_container` がフォールバック値を使うという既存の問題を根本解決する。

## 変更内容

- `AppState::Loading` を追加し、デフォルトステートに設定（旧: `Title`）
- `wait_for_configs` システムを追加 — physics/fruits/game_rules/bounce/droplet/flash の全6configロード完了を確認してから `Title` へ遷移
- `setup_container` を `Startup` から `OnExit(AppState::Loading)` に移動
- `container.rs` のフォールバック値と `warn!` を削除し、`.expect()` に置き換え
- 関連テストを `Loading` デフォルト対応に更新

## テスト

- [x] `cargo test --workspace` 全テストパス
- [x] `cargo clippy --workspace -- -D warnings` 警告なし
- [x] `cargo build --workspace` ビルド成功