### PR TITLE
refactor: カメラ・コンテナ・入力・永続化をプラグインへ移動

### DIFF
--- a/app/core/src/config.rs
+++ b/app/core/src/config.rs
@@ -6,10 +6,10 @@
 //! Supports hot-reloading: Edit config files while the game is running
 //! and changes will be applied automatically.
 
+use crate::states::AppState;
 use bevy::asset::io::Reader;
 use bevy::asset::{Asset, AssetLoader, LoadContext};
 use bevy::prelude::*;
-use crate::states::AppState;
 use bevy_rapier2d::prelude::{
     Collider, ColliderMassProperties, DefaultRapierContext, Friction, RapierConfiguration,
     Restitution,
@@ -286,10 +286,7 @@ impl Plugin for GameConfigPlugin {
         );
 
         // Transition Loading → Title once all required configs are ready
-        app.add_systems(
-            Update,
-            wait_for_configs.run_if(in_state(AppState::Loading)),
-        );
+        app.add_systems(Update, wait_for_configs.run_if(in_state(AppState::Loading)));
 
         info!("✅ GameConfigPlugin initialized");
         info!(
@@ -305,6 +302,7 @@ impl Plugin for GameConfigPlugin {
 /// As soon as all three are available the state machine advances to `Title` so
 /// the rest of the game — including `setup_container` via `OnExit(Loading)` —
 /// can use fully-loaded values instead of fallbacks.
+#[allow(clippy::too_many_arguments)]
 fn wait_for_configs(
     physics_handle: Res<PhysicsConfigHandle>,
     physics_assets: Res<Assets<PhysicsConfig>>,
@@ -327,7 +325,9 @@ fn wait_for_configs(
         && droplet_assets.get(&droplet_handle.0).is_some()
         && flash_assets.get(&flash_handle.0).is_some()
     {
-        info!("✅ All configs loaded (physics, fruits, game_rules, bounce, droplet, flash), transitioning to Title");
+        info!(
+            "✅ All configs loaded (physics, fruits, game_rules, bounce, droplet, flash), transitioning to Title"
+        );
         next_state.set(AppState::Title);
     }
 }

--- a/app/core/src/persistence.rs
+++ b/app/core/src/persistence.rs
@@ -3,10 +3,17 @@
 //! This module handles saving and loading the player's highscore
 //! to/from a JSON file on disk. The highscore persists across
 //! game sessions.
+//!
+//! Also exposes [`load_highscore_startup`], a Bevy startup system that reads
+//! the persisted highscore into [`GameState`] once at launch.
 
+use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
+
+use crate::constants::storage::SAVE_DIR;
+use crate::resources::GameState;
 
 /// Highscore data structure
 ///
@@ -147,6 +154,17 @@ pub fn update_highscore(
     } else {
         Ok(false)
     }
+}
+
+/// Bevy startup system: reads the persisted highscore into [`GameState`].
+///
+/// Runs once at [`Startup`] so every screen that shows the best score
+/// (title screen, HUD, game-over screen) always has the correct value
+/// from the very first frame.
+pub fn load_highscore_startup(mut game_state: ResMut<GameState>) {
+    let data = load_highscore(std::path::Path::new(SAVE_DIR));
+    game_state.highscore = data.highscore;
+    info!("Highscore loaded: {}", data.highscore);
 }
 
 #[cfg(test)]

--- a/app/core/src/states.rs
+++ b/app/core/src/states.rs
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_app_state_all_variants() {
         // Ensure all variants are covered
-        let states = vec![
+        let states = [
             AppState::Loading,
             AppState::Title,
             AppState::Playing,

--- a/app/core/src/systems/container.rs
+++ b/app/core/src/systems/container.rs
@@ -1,32 +1,24 @@
-//! Game Container (Box) Implementation
+//! Game container (physics box) setup.
 //!
-//! This module handles the creation and setup of the game container,
-//! which consists of three fixed walls: left, right, and bottom.
-//! The walls use Rapier2D physics bodies to contain the fruits.
+//! Spawns the three fixed walls (left, right, bottom) and the visual boundary
+//! line that marks the game-over threshold.  The system reads all dimensions
+//! from [`PhysicsConfig`] so the container automatically matches whatever
+//! values are in `physics.ron`.
+//!
+//! Registered by [`crate::GameCorePlugin`] on [`OnExit(AppState::Loading)`] so
+//! the config is guaranteed to be fully loaded before the walls are spawned.
 
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
-use suika_game_core::prelude::*;
 
-/// Sets up the game container with physics walls
+use crate::components::{BottomWall, BoundaryLine, Container, LeftWall, RightWall};
+use crate::config::{PhysicsConfig, PhysicsConfigHandle};
+
+/// Spawns the three physics walls and the visual boundary line.
 ///
-/// Creates three fixed walls:
-/// - Left wall: positioned at the left edge of the container
-/// - Right wall: positioned at the right edge of the container
-/// - Bottom wall: positioned at the bottom of the container
-///
-/// Each wall is configured with:
-/// - RigidBody::Fixed (immovable)
-/// - Collider (box shape)
-/// - Friction coefficient (0.5)
-/// - Restitution coefficient (0.3)
-/// - Visual sprite representation
-///
-/// # Container Dimensions
-///
-/// Loaded from `PhysicsConfig`:
-/// - Width, height, wall thickness from physics.ron
-/// - Wall restitution and friction from config
+/// All dimensions are sourced from [`PhysicsConfig`].  The system is
+/// intentionally registered on `OnExit(AppState::Loading)` so the config is
+/// guaranteed to be loaded — calling `.expect()` here is safe by design.
 pub fn setup_container(
     mut commands: Commands,
     physics_handle: Res<PhysicsConfigHandle>,
@@ -37,6 +29,7 @@ pub fn setup_container(
     let config = physics_assets
         .get(&physics_handle.0)
         .expect("PhysicsConfig must be loaded before setup_container runs");
+
     let (container_width, container_height, wall_thickness, wall_restitution, wall_friction) = (
         config.container_width,
         config.container_height,
@@ -45,14 +38,13 @@ pub fn setup_container(
         config.wall_friction,
     );
 
-    // Calculate wall positions
     let half_width = container_width / 2.0;
     let half_height = container_height / 2.0;
 
     // Left wall
     commands.spawn((
         Container,
-        LeftWall, // Marker for hot-reload wall identification
+        LeftWall,
         RigidBody::Fixed,
         Collider::cuboid(wall_thickness / 2.0, half_height),
         Friction::coefficient(wall_friction),
@@ -72,7 +64,7 @@ pub fn setup_container(
     // Right wall
     commands.spawn((
         Container,
-        RightWall, // Marker for hot-reload wall identification
+        RightWall,
         RigidBody::Fixed,
         Collider::cuboid(wall_thickness / 2.0, half_height),
         Friction::coefficient(wall_friction),
@@ -89,15 +81,15 @@ pub fn setup_container(
         },
     ));
 
-    // Bottom wall (no bounce - matches original Suika Game behavior)
+    // Bottom wall — no bounce, matches original Suika Game behavior
     commands.spawn((
         Container,
-        BottomWall, // Marker for landing detection
+        BottomWall,
         RigidBody::Fixed,
         Collider::cuboid(half_width + wall_thickness, wall_thickness / 2.0),
         Friction::coefficient(wall_friction),
         Restitution {
-            coefficient: 0.0, // No bounce on ground
+            coefficient: 0.0,
             combine_rule: CoefficientCombineRule::Min,
         },
         ActiveEvents::COLLISION_EVENTS,
@@ -112,15 +104,13 @@ pub fn setup_container(
         },
     ));
 
-    // Boundary line (game over line) - visual only, no physics
-    let boundary_y = config.boundary_line_y;
+    // Boundary line — visual only, no physics
     let line_thickness = 3.0;
-
     commands.spawn((
         BoundaryLine,
-        Transform::from_xyz(0.0, boundary_y, 0.0),
+        Transform::from_xyz(0.0, config.boundary_line_y, 0.0),
         Sprite {
-            color: Color::srgba(1.0, 0.0, 0.0, 0.5), // Red semi-transparent
+            color: Color::srgba(1.0, 0.0, 0.0, 0.5),
             custom_size: Some(Vec2::new(container_width, line_thickness)),
             ..default()
         },
@@ -129,15 +119,17 @@ pub fn setup_container(
     info!("Game container initialized with 3 walls and boundary line");
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Helper to create a test app with necessary resources
     fn setup_test_app() -> App {
         let mut app = App::new();
 
-        // Add required resources for setup_container
         let mut physics_assets = Assets::<PhysicsConfig>::default();
         let physics_config = PhysicsConfig {
             gravity: -980.0,
@@ -166,10 +158,12 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify 3 container walls exist
         let mut query = app.world_mut().query::<&Container>();
-        let wall_count = query.iter(app.world()).count();
-        assert_eq!(wall_count, 3, "Should have exactly 3 container walls");
+        assert_eq!(
+            query.iter(app.world()).count(),
+            3,
+            "Should have exactly 3 container walls"
+        );
     }
 
     #[test]
@@ -178,10 +172,8 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify all walls have RigidBody::Fixed
         let mut query = app.world_mut().query::<(&Container, &RigidBody)>();
         let walls: Vec<_> = query.iter(app.world()).collect();
-
         assert_eq!(walls.len(), 3);
         for (_, body) in walls {
             assert_eq!(*body, RigidBody::Fixed);
@@ -194,10 +186,12 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify all walls have colliders
         let mut query = app.world_mut().query::<(&Container, &Collider)>();
-        let collider_count = query.iter(app.world()).count();
-        assert_eq!(collider_count, 3, "All walls should have colliders");
+        assert_eq!(
+            query.iter(app.world()).count(),
+            3,
+            "All walls should have colliders"
+        );
     }
 
     #[test]
@@ -206,7 +200,6 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify friction coefficient
         let mut query = app.world_mut().query::<(&Container, &Friction)>();
         for (_, friction) in query.iter(app.world()) {
             assert_eq!(friction.coefficient, 0.5);
@@ -219,16 +212,13 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify restitution coefficient for side walls (0.3)
         let mut query = app
             .world_mut()
             .query::<(&Container, &Restitution, Option<&BottomWall>)>();
         for (_, restitution, bottom_wall) in query.iter(app.world()) {
             if bottom_wall.is_some() {
-                // Bottom wall should have no bounce
                 assert_eq!(restitution.coefficient, 0.0);
             } else {
-                // Side walls should have some bounce (from physics.ron)
                 assert_eq!(restitution.coefficient, 0.2);
             }
         }
@@ -240,10 +230,12 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify all walls have sprites
         let mut query = app.world_mut().query::<(&Container, &Sprite)>();
-        let sprite_count = query.iter(app.world()).count();
-        assert_eq!(sprite_count, 3, "All walls should have sprites");
+        assert_eq!(
+            query.iter(app.world()).count(),
+            3,
+            "All walls should have sprites"
+        );
     }
 
     #[test]
@@ -252,10 +244,12 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify exactly one boundary line exists
         let mut query = app.world_mut().query::<&BoundaryLine>();
-        let boundary_count = query.iter(app.world()).count();
-        assert_eq!(boundary_count, 1, "Should have exactly one boundary line");
+        assert_eq!(
+            query.iter(app.world()).count(),
+            1,
+            "Should have exactly one boundary line"
+        );
     }
 
     #[test]
@@ -264,7 +258,6 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify boundary line Y position matches the test config value
         let mut query = app.world_mut().query::<(&BoundaryLine, &Transform)>();
         for (_, transform) in query.iter(app.world()) {
             assert_eq!(
@@ -280,19 +273,17 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify boundary line has no RigidBody
         let mut query = app.world_mut().query::<(&BoundaryLine, &RigidBody)>();
-        let rigid_body_count = query.iter(app.world()).count();
         assert_eq!(
-            rigid_body_count, 0,
+            query.iter(app.world()).count(),
+            0,
             "Boundary line should not have a RigidBody (visual only)"
         );
 
-        // Verify boundary line has no Collider
         let mut query = app.world_mut().query::<(&BoundaryLine, &Collider)>();
-        let collider_count = query.iter(app.world()).count();
         assert_eq!(
-            collider_count, 0,
+            query.iter(app.world()).count(),
+            0,
             "Boundary line should not have a Collider (visual only)"
         );
     }
@@ -303,12 +294,13 @@ mod tests {
         app.add_systems(Startup, setup_container);
         app.update();
 
-        // Verify boundary line has a sprite
         let mut query = app.world_mut().query::<(&BoundaryLine, &Sprite)>();
-        let sprite_count = query.iter(app.world()).count();
-        assert_eq!(sprite_count, 1, "Boundary line should have a sprite");
+        assert_eq!(
+            query.iter(app.world()).count(),
+            1,
+            "Boundary line should have a sprite"
+        );
 
-        // Verify the sprite color is red with transparency
         let mut query = app.world_mut().query::<(&BoundaryLine, &Sprite)>();
         for (_, sprite) in query.iter(app.world()) {
             let color = sprite.color.to_srgba();

--- a/app/core/src/systems/mod.rs
+++ b/app/core/src/systems/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod boundary;
 pub mod collision;
+pub mod container;
 pub mod effects;
 pub mod game_over;
 pub mod input;

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -1,25 +1,17 @@
-mod camera;
-mod container;
 mod debug;
 
 use bevy::prelude::*;
 use bevy_kira_audio::AudioPlugin;
 use bevy_rapier2d::prelude::*;
 
-use camera::setup_camera;
-use container::setup_container;
 use debug::DebugPlugin;
 use suika_game_assets::GameAssetsPlugin;
 use suika_game_audio::GameAudioPlugin;
 use suika_game_core::prelude::*;
-use suika_game_core::systems::input::{
-    detect_fruit_landing, handle_fruit_drop_input, spawn_held_fruit, update_spawn_position,
-};
 use suika_game_ui::GameUIPlugin;
 
 fn main() {
     App::new()
-        // Bevy default plugins
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "スイカゲーム".to_string(),
@@ -28,45 +20,13 @@ fn main() {
             }),
             ..default()
         }))
-        // External plugins
-        // Rapier physics with 100 pixels per meter scaling
-        // Default gravity is -9.81 m/s², which equals -981 pixels/s²
-        // This is approximately our target of -980 pixels/s² (configurable in physics.ron)
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
         .add_plugins(AudioPlugin)
-        // Game plugins (internal crates)
-        // Note: GameCorePlugin initializes AppState and all game resources
-        .add_plugins(GameAssetsPlugin) // Load assets first
-        .add_plugins(GameConfigPlugin) // Load game configuration
+        .add_plugins(GameAssetsPlugin)
+        .add_plugins(GameConfigPlugin)
         .add_plugins(GameCorePlugin)
         .add_plugins(GameUIPlugin)
         .add_plugins(GameAudioPlugin)
-        // Debug plugin (debug builds only)
         .add_plugins(DebugPlugin)
-        // Startup systems
-        .add_systems(Startup, (setup_camera, load_highscore_system))
-        // setup_container runs on exit from Loading so physics.ron is guaranteed loaded
-        .add_systems(OnExit(AppState::Loading), setup_container)
-        // Gameplay systems — only run while actively playing
-        .add_systems(
-            Update,
-            (
-                update_spawn_position,
-                handle_fruit_drop_input.after(update_spawn_position),
-                detect_fruit_landing,
-                spawn_held_fruit.after(detect_fruit_landing),
-            )
-                .run_if(in_state(AppState::Playing)),
-        )
         .run();
-}
-
-/// Loads the highscore from disk at startup.
-///
-/// Runs once during app initialization and populates [`GameState::highscore`]
-/// so the title screen can display the current best score immediately.
-fn load_highscore_system(mut game_state: ResMut<GameState>) {
-    let highscore_data = load_highscore(std::path::Path::new(constants::storage::SAVE_DIR));
-    game_state.highscore = highscore_data.highscore;
-    info!("Highscore loaded from disk: {}", highscore_data.highscore);
 }

--- a/app/suika-game/tests/integration_test.rs
+++ b/app/suika-game/tests/integration_test.rs
@@ -51,8 +51,7 @@ fn test_resources_available() {
     let _game_over_timer = GameOverTimer::default();
     let _next_fruit = NextFruitType::default();
 
-    // If we got here, all resources can be created
-    assert!(true, "All game resources are available");
+    // If we got here without panicking, all resources can be created
 }
 
 #[test]
@@ -77,6 +76,5 @@ fn test_physics_configuration() {
     app.add_plugins(MinimalPlugins);
     app.add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0));
 
-    // Should initialize without panicking
-    assert!(true, "Physics plugin initialized successfully");
+    // If we got here without panicking, the plugin initialized successfully
 }

--- a/app/ui/src/camera.rs
+++ b/app/ui/src/camera.rs
@@ -1,48 +1,32 @@
-//! 2.5D Camera Setup
+//! Camera setup for the game.
 //!
-//! This module handles the camera configuration for the game's
-//! 2.5D oblique overhead view. The camera uses orthographic projection
-//! and is angled to provide depth perception while maintaining
-//! 2D physics simulation.
+//! Spawns the single orthographic [`Camera2d`] used to render the game world.
+//! Registered by [`crate::GameUIPlugin`] at [`Startup`] so the camera is
+//! available from the very first frame, before any state transitions occur.
 
 use bevy::prelude::*;
 
-/// Sets up the 2.5D camera for the game
+/// Spawns the orthographic camera used to render the game world.
 ///
-/// This system creates an orthographic camera with the following properties:
-/// - Orthographic projection (no perspective distortion)
-/// - Positioned along the Z-axis, looking straight down at the game plane
-/// - Z-axis is used for sprite layering (higher Z = closer to camera)
-///
-/// # Camera Configuration
-///
-/// The camera is positioned for a top-down orthographic view:
-/// - X: 0.0 (centered horizontally)
-/// - Y: 0.0 (centered vertically)
-/// - Z: 999.9 (far from the game plane, allowing sprites with Z < 999.9 to render)
-///
-/// # 2.5D Effect
-///
-/// The "2.5D" visual effect is achieved through Z-based sprite layering,
-/// not through camera rotation. Sprites can use different Z values to
-/// control rendering order and create depth perception while the physics
-/// simulation remains strictly 2D on the X-Y plane.
-///
-/// The projection is orthographic with a scale that fits the game container.
+/// The camera is positioned on the Z axis so that all sprites with
+/// `z < 999.9` are visible.  The orthographic scale is `1.0`, meaning
+/// one world unit equals one logical pixel.
 pub fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
         Transform::from_xyz(0.0, 0.0, 999.9),
         Projection::Orthographic(OrthographicProjection {
-            // Set the scale to show the entire game area
-            // The viewport will be scaled to fit the window
             scale: 1.0,
             ..OrthographicProjection::default_2d()
         }),
     ));
 
-    info!("2.5D camera initialized");
+    info!("Camera initialized");
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -54,10 +38,12 @@ mod tests {
         app.add_systems(Startup, setup_camera);
         app.update();
 
-        // Verify camera entity exists
         let mut query = app.world_mut().query::<&Camera2d>();
-        let camera_count = query.iter(app.world()).count();
-        assert_eq!(camera_count, 1, "Should have exactly one camera");
+        assert_eq!(
+            query.iter(app.world()).count(),
+            1,
+            "Should have exactly one camera"
+        );
     }
 
     #[test]
@@ -66,7 +52,6 @@ mod tests {
         app.add_systems(Startup, setup_camera);
         app.update();
 
-        // Verify camera transform
         let mut query = app.world_mut().query::<(&Camera2d, &Transform)>();
         let Ok((_, transform)) = query.single(app.world()) else {
             panic!("Camera not found");
@@ -83,7 +68,6 @@ mod tests {
         app.add_systems(Startup, setup_camera);
         app.update();
 
-        // Verify orthographic projection exists
         let mut query = app.world_mut().query::<(&Camera2d, &Projection)>();
         let Ok((_, projection)) = query.single(app.world()) else {
             panic!("Camera projection not found");

--- a/app/ui/src/lib.rs
+++ b/app/ui/src/lib.rs
@@ -5,6 +5,7 @@
 use bevy::prelude::*;
 use suika_game_core::prelude::AppState;
 
+pub mod camera;
 pub mod components;
 pub mod config;
 pub mod screens;
@@ -23,7 +24,8 @@ impl Plugin for GameUIPlugin {
         // Background color comes from the UI style palette
         app.insert_resource(ClearColor(styles::BG_COLOR));
 
-        app.init_resource::<components::KeyboardFocusIndex>()
+        app.add_systems(Startup, camera::setup_camera)
+            .init_resource::<components::KeyboardFocusIndex>()
             // Title screen
             .add_systems(OnEnter(AppState::Title), screens::title::setup_title_screen)
             // HUD: spawn layout on enter Playing, run widget updates each frame


### PR DESCRIPTION
## 概要

`main.rs` に散在していたゲームロジックを各担当プラグインへ移動し、`main.rs` をプラグイン登録のみに整理した。

## 変更内容

- **camera.rs** を `suika-game` → `app/ui/src/camera.rs` へ移動し、`GameUIPlugin` で登録
- **container.rs** を `suika-game` → `app/core/src/systems/container.rs` へ移動し、`GameCorePlugin` (`OnExit(Loading)`) で登録
- **load_highscore_system** を `persistence::load_highscore_startup` として `persistence.rs` に移動し、`GameCorePlugin` (`Startup`) で登録
- **ゲームプレイ入力システム** を `main.rs` から `GameCorePlugin` (`Update`、`Playing` 限定) へ移動
- `wait_for_configs` を全6 RON設定（physics / fruits / game_rules / bounce / droplet / flash）に拡張
- `main.rs` はプラグイン登録のみになり、ゲームロジックを含まない

## テスト

- [x] `cargo test --workspace` 全テスト通過
- [x] `cargo clippy --workspace` 警告なし
- [x] ゲーム起動・プレイで動作確認

## 関連

この変更はローディング状態実装 (#113) の後続リファクタとして実施。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent highscore automatically loads when the game starts, restoring your previous progress

* **Improvements**
  * Game systems reorganized to run at appropriate state transitions (Loading, Title, Playing)
  * Gameplay input systems now activate only during active gameplay
  * Container boundaries and walls configured from centralized configuration values
  * Camera initialization simplified and streamlined

<!-- end of auto-generated comment: release notes by coderabbit.ai -->