### PR TITLE
feat(audio): integrate bevy_kira_audio via GameAudioPlugin

### DIFF
--- a/app/audio/src/lib.rs
+++ b/app/audio/src/lib.rs
@@ -1,23 +1,55 @@
-//! # game-audio
+//! Audio management for Suika Game.
 //!
-//! オーディオ管理：BGMと効果音の再生
+//! Wraps [`bevy_kira_audio`] and registers all BGM / SFX systems.
+//! The [`GameAudioPlugin`] is the single entry-point: add it to the Bevy
+//! [`App`] in `main.rs` — it internally adds [`bevy_kira_audio::AudioPlugin`]
+//! so no other audio setup is needed at the application level.
+//!
+//! # Module layout (future tasks)
+//!
+//! | Module | Responsibility |
+//! |--------|---------------|
+//! | `handles` | Load & store `Handle<AudioSource>` for every asset |
+//! | `bgm`     | BGM playback, state-driven track switching |
+//! | `sfx`     | SFX playback (merge, combo, UI, game-over) |
 
 use bevy::prelude::*;
+use bevy_kira_audio::AudioPlugin as KiraAudioPlugin;
 
-// TODO: モジュールの追加
+// Future modules (uncomment as tasks are completed):
 // pub mod bgm;
+// pub mod handles;
 // pub mod sfx;
 
-/// オーディオプラグイン
+/// Integrates [`bevy_kira_audio`] into the game and registers all audio systems.
+///
+/// Add this plugin to your [`App`] once; it owns the kira audio backend setup.
+///
+/// ```rust,no_run
+/// use bevy::prelude::*;
+/// use suika_game_audio::GameAudioPlugin;
+///
+/// App::new()
+///     .add_plugins(DefaultPlugins)
+///     .add_plugins(GameAudioPlugin)
+///     .run();
+/// ```
 pub struct GameAudioPlugin;
 
 impl Plugin for GameAudioPlugin {
-    fn build(&self, _app: &mut App) {
-        info!("GameAudioPlugin initialized");
+    fn build(&self, app: &mut App) {
+        // Add the kira audio backend.  All other audio plugins/systems rely on
+        // this being registered first.
+        app.add_plugins(KiraAudioPlugin);
 
-        // TODO: オーディオシステムの登録
+        info!("GameAudioPlugin initialized (bevy_kira_audio ready)");
+
+        // TODO: register systems when subsequent audio tasks are implemented:
         // app
-        //     .add_systems(Startup, load_audio_assets)
-        //     .add_systems(Update, (switch_bgm, play_sfx));
+        //     .init_resource::<CurrentBgm>()
+        //     .add_systems(Startup, handles::load_audio_assets)
+        //     .add_systems(Update, bgm::switch_bgm_on_state_change)
+        //     .add_systems(Update, (sfx::play_merge_sfx, sfx::play_combo_sfx, sfx::play_ui_sfx))
+        //     .add_systems(OnEnter(AppState::GameOver), sfx::play_gameover_sfx);
     }
 }

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -1,7 +1,6 @@
 mod debug;
 
 use bevy::prelude::*;
-use bevy_kira_audio::AudioPlugin;
 use bevy_rapier2d::prelude::*;
 
 use debug::DebugPlugin;
@@ -21,7 +20,6 @@ fn main() {
             ..default()
         }))
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
-        .add_plugins(AudioPlugin)
         .add_plugins(GameAssetsPlugin)
         .add_plugins(GameConfigPlugin)
         .add_plugins(GameCorePlugin)


### PR DESCRIPTION
## 概要
`GameAudioPlugin` が `bevy_kira_audio::AudioPlugin` を内部で追加するよう変更。`main.rs` にあった重複した `.add_plugins(AudioPlugin)` を削除し、オーディオクレートを自己完結型にした。

## 変更内容
- `app/audio/src/lib.rs`: `KiraAudioPlugin` を `GameAudioPlugin::build()` 内で追加、将来の `handles` / `bgm` / `sfx` モジュールのコメントを追加
- `app/suika-game/src/main.rs`: `use bevy_kira_audio::AudioPlugin` と `.add_plugins(AudioPlugin)` を削除（`GameAudioPlugin` が内包）

## テスト
- [x] `just check` 実行済み（fmt + clippy 共にパス）
- [x] `just test` 実行済み（全テストパス）
- [x] `just build` 実行済み（ビルドエラーなし）

Closes #56