### PR TITLE
feat(ui): リザルト画面に経過時間を表示する

### DIFF
--- a/app/ui/src/screens/game_over.rs
+++ b/app/ui/src/screens/game_over.rs
@@ -5,6 +5,7 @@
 //! - The **final score** in large text
 //! - A **NEW RECORD!** banner when a new highscore was achieved
 //! - The **all-time highscore**
+//! - The **elapsed time** for this run in `M:SS` format
 //! - A **Retry** button (→ [`AppState::Playing`])
 //! - A **Title** button (→ [`AppState::Title`])
 //!
@@ -16,6 +17,7 @@ use bevy::prelude::*;
 use suika_game_core::prelude::{AppState, GameState};
 
 use crate::components::{ButtonAction, KeyboardFocusIndex, spawn_button};
+use crate::screens::hud::format_elapsed;
 use crate::styles::{
     BG_COLOR, BUTTON_LARGE_HEIGHT, BUTTON_LARGE_WIDTH, BUTTON_MEDIUM_HEIGHT, BUTTON_MEDIUM_WIDTH,
     FONT_JP, FONT_SIZE_HUGE, FONT_SIZE_LARGE, FONT_SIZE_MEDIUM, FONT_SIZE_SMALL, HIGHLIGHT_COLOR,
@@ -120,6 +122,24 @@ pub fn setup_game_over_screen(
                 Text::new(format!(
                     "ハイスコア: {}",
                     format_score(game_state.highscore)
+                )),
+                TextFont {
+                    font: font.clone(),
+                    font_size: FONT_SIZE_SMALL,
+                    ..default()
+                },
+                TextColor(TEXT_COLOR),
+                Node {
+                    margin: UiRect::bottom(Val::Px(10.0)),
+                    ..default()
+                },
+            ));
+
+            // Elapsed time for this run
+            parent.spawn((
+                Text::new(format!(
+                    "プレイ時間: {}",
+                    format_elapsed(game_state.elapsed_time as u32)
                 )),
                 TextFont {
                     font: font.clone(),


### PR DESCRIPTION
## 概要

ゲームオーバー後のリザルト画面に、今回のプレイ時間を `M:SS` 形式で表示する。
プレイ中は表示せずリザルトのみに留めることで、スイカゲームの緩やかなプレイ感を維持する。

## 変更内容

- `app/ui/src/screens/game_over.rs` にプレイ時間行を追加（ハイスコアの直下）
- 既存の `GameState::elapsed_time`（`tick_elapsed_time` で計測済み）を利用
- 既存の `format_elapsed()` (`hud::mod`) で `M:SS` 形式にフォーマット
- プレイ中 HUD へのタイマー表示は行わない

## テスト

- [x] ワークスペース全テストパス（`cargo test --workspace`）
- [x] `cargo fmt` / `cargo clippy` クリーン
- [x] ゲーム内でリザルト画面の経過時間表示を確認

Closes #68