### PR TITLE
feat(core): フルーツの大きさに応じてパーティクル数をスケール

### DIFF
--- a/app/core/src/fruit.rs
+++ b/app/core/src/fruit.rs
@@ -114,6 +114,14 @@ impl FruitType {
         })
     }
 
+    /// Returns the zero-based stage index of this fruit type.
+    ///
+    /// Cherry = 0, Strawberry = 1, …, Watermelon = 10.
+    /// Used to scale size-dependent effects (e.g. particle count).
+    pub fn stage_index(&self) -> usize {
+        *self as usize
+    }
+
     /// Returns the array of fruits that can be spawned by the player
     ///
     /// Only the first 5 fruits (Cherry through Persimmon) can be spawned.
@@ -179,6 +187,36 @@ mod tests {
         assert_eq!(spawnable[2], FruitType::Grape);
         assert_eq!(spawnable[3], FruitType::Dekopon);
         assert_eq!(spawnable[4], FruitType::Persimmon);
+    }
+
+    #[test]
+    fn test_stage_index_order() {
+        assert_eq!(FruitType::Cherry.stage_index(), 0);
+        assert_eq!(FruitType::Strawberry.stage_index(), 1);
+        assert_eq!(FruitType::Watermelon.stage_index(), 10);
+    }
+
+    #[test]
+    fn test_stage_index_monotone() {
+        let fruits = [
+            FruitType::Cherry,
+            FruitType::Strawberry,
+            FruitType::Grape,
+            FruitType::Dekopon,
+            FruitType::Persimmon,
+            FruitType::Apple,
+            FruitType::Pear,
+            FruitType::Peach,
+            FruitType::Pineapple,
+            FruitType::Melon,
+            FruitType::Watermelon,
+        ];
+        for window in fruits.windows(2) {
+            assert!(
+                window[0].stage_index() < window[1].stage_index(),
+                "stage_index must be strictly increasing along the evolution chain"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 概要
フルーツのステージ（大きさ）に応じて水滴・果汁パーティクルの発生数を増やす。Cherry（最小）はそのまま、Watermelon（最大）は3倍のパーティクルを生成する。

## 変更内容
- `FruitType::stage_index()` を追加（Cherry=0 … Watermelon=10）
- `scale_count_by_fruit(base, fruit_type)` ヘルパー追加（1× → 3× リニアスケール）
- `spawn_merge_droplets` と `handle_fruit_landing` 両方に適用
- ユニットテスト追加（stage_index 単調増加、Cherry=base、Watermelon=3倍）

## テスト
- [x] ユニットテスト追加・全パス
- [x] `just check` 実行済み

Closes #133