### PR TITLE
feat(core): WGSLシェーダーベースのビジュアルエフェクト基盤を実装

### DIFF
--- a/app/core/src/resources/mod.rs
+++ b/app/core/src/resources/mod.rs
@@ -9,12 +9,14 @@ pub mod game;
 pub mod game_over;
 pub mod settings;
 pub mod spawn;
+pub mod weather;
 
 pub use combo::ComboTimer;
 pub use game::GameState;
 pub use game_over::GameOverTimer;
 pub use settings::{Language, SettingsResource};
 pub use spawn::NextFruitType;
+pub use weather::{CurrentWeather, WeatherParams, WeatherState};
 
 #[cfg(test)]
 mod tests {

--- a/app/core/src/resources/weather.rs
+++ b/app/core/src/resources/weather.rs
@@ -1,0 +1,177 @@
+//! Weather system — current weather state and visual parameters.
+//!
+//! The weather for each game session is determined randomly when the player
+//! enters [`crate::states::AppState::Playing`].  It remains constant for the
+//! duration of that session and drives rain particles, screen-droplet spawning,
+//! the full-screen colour overlay, and the camera bloom setting.
+
+use bevy::prelude::*;
+use rand::RngExt;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// One of three possible weather conditions for a play session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WeatherState {
+    /// Clear sunny conditions — camera bloom, warm sky.
+    #[default]
+    Sunny,
+    /// Rain — falling rain particles, screen droplets, cool blue colour cast.
+    Rainy,
+    /// Overcast — grey desaturated overlay, no rain.
+    Cloudy,
+}
+
+/// Visual and gameplay parameters derived from a [`WeatherState`].
+#[derive(Debug, Clone, Copy)]
+pub struct WeatherParams {
+    /// Maximum simultaneous rain-drop particles (0 = no rain).
+    pub max_rain_particles: u32,
+    /// Random screen-droplet spawn events per second during rain (0 = none).
+    pub screen_droplet_rate: f32,
+    /// RGBA colour for the full-screen weather overlay (alpha=0 → no overlay).
+    pub overlay_color: [f32; 4],
+    /// Whether to enable camera bloom.
+    pub bloom: bool,
+    /// Bloom intensity (ignored when `bloom` is false).
+    pub bloom_intensity: f32,
+}
+
+impl WeatherState {
+    /// Returns the visual/gameplay parameters for this weather state.
+    pub fn params(self) -> WeatherParams {
+        match self {
+            WeatherState::Sunny => WeatherParams {
+                max_rain_particles: 0,
+                screen_droplet_rate: 0.0,
+                overlay_color: [0.0, 0.0, 0.0, 0.0], // transparent — no overlay
+                bloom: true,
+                bloom_intensity: 0.25,
+            },
+            WeatherState::Rainy => WeatherParams {
+                max_rain_particles: 200,
+                screen_droplet_rate: 0.4,
+                overlay_color: [0.04, 0.04, 0.12, 0.10],
+                bloom: false,
+                bloom_intensity: 0.0,
+            },
+            WeatherState::Cloudy => WeatherParams {
+                max_rain_particles: 0,
+                screen_droplet_rate: 0.0,
+                overlay_color: [0.08, 0.08, 0.08, 0.07],
+                bloom: false,
+                bloom_intensity: 0.0,
+            },
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+/// The current weather for the active game session.
+///
+/// Initialised to [`WeatherState::Sunny`] (default) and randomised by
+/// [`randomize_weather`] on every `OnEnter(AppState::Playing)`.
+#[derive(Resource, Debug, Default)]
+pub struct CurrentWeather {
+    /// The active weather condition.
+    pub state: WeatherState,
+}
+
+// ---------------------------------------------------------------------------
+// System
+// ---------------------------------------------------------------------------
+
+/// Selects a random [`WeatherState`] at the start of each play session.
+///
+/// Registered by [`crate::GameCorePlugin`] on `OnEnter(AppState::Playing)`.
+/// The three weather conditions are equally likely (~33 % each).
+pub fn randomize_weather(mut weather: ResMut<CurrentWeather>) {
+    let mut rng = rand::rng();
+    let roll: f32 = rng.random();
+    weather.state = if roll < 0.333 {
+        WeatherState::Sunny
+    } else if roll < 0.667 {
+        WeatherState::Rainy
+    } else {
+        WeatherState::Cloudy
+    };
+    info!("Weather randomised → {:?}", weather.state);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_weather_state_default_is_sunny() {
+        assert_eq!(WeatherState::default(), WeatherState::Sunny);
+    }
+
+    #[test]
+    fn test_current_weather_default() {
+        let w = CurrentWeather::default();
+        assert_eq!(w.state, WeatherState::Sunny);
+    }
+
+    #[test]
+    fn test_sunny_params() {
+        let p = WeatherState::Sunny.params();
+        assert_eq!(p.max_rain_particles, 0);
+        assert!(p.bloom);
+        assert!(p.bloom_intensity > 0.0);
+        // No overlay colour
+        assert_eq!(p.overlay_color[3], 0.0);
+    }
+
+    #[test]
+    fn test_rainy_params() {
+        let p = WeatherState::Rainy.params();
+        assert!(p.max_rain_particles > 0, "Rainy should have rain particles");
+        assert!(
+            p.screen_droplet_rate > 0.0,
+            "Rainy should spawn screen droplets"
+        );
+        assert!(
+            p.overlay_color[3] > 0.0,
+            "Rainy should have a visible overlay"
+        );
+        assert!(!p.bloom);
+    }
+
+    #[test]
+    fn test_cloudy_params() {
+        let p = WeatherState::Cloudy.params();
+        assert_eq!(p.max_rain_particles, 0);
+        assert_eq!(p.screen_droplet_rate, 0.0);
+        assert!(
+            p.overlay_color[3] > 0.0,
+            "Cloudy should have a visible overlay"
+        );
+        assert!(!p.bloom);
+    }
+
+    #[test]
+    fn test_randomize_weather_produces_valid_state() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<CurrentWeather>();
+        app.add_systems(bevy::app::Startup, randomize_weather);
+        app.update();
+
+        let weather = app.world().resource::<CurrentWeather>();
+        let valid = matches!(
+            weather.state,
+            WeatherState::Sunny | WeatherState::Rainy | WeatherState::Cloudy
+        );
+        assert!(valid, "randomize_weather must produce a valid WeatherState");
+    }
+}

--- a/app/core/src/shaders/mod.rs
+++ b/app/core/src/shaders/mod.rs
@@ -1,0 +1,248 @@
+//! WGSL shader materials for 2D visual effects.
+//!
+//! Defines [`Material2d`] types used by particle and overlay systems, plus
+//! shared mesh-handle resources.  WGSL source files live in the game's
+//! `assets/shaders/` directory and are loaded by Bevy's `AssetServer` at
+//! runtime (the standard Bevy 0.17 approach for application shaders).
+//!
+//! # Usage
+//!
+//! Add [`ShadersPlugin`] to the application **after** `DefaultPlugins`
+//! (which includes the rendering and asset plugins):
+//!
+//! ```no_run
+//! use bevy::prelude::*;
+//! use suika_game_core::shaders::ShadersPlugin;
+//!
+//! fn main() {
+//!     App::new()
+//!         .add_plugins(DefaultPlugins)
+//!         .add_plugins(ShadersPlugin)
+//!         .run();
+//! }
+//! ```
+//!
+//! When `ShadersPlugin` is **not** present (e.g. in headless tests), systems
+//! that accept `Option<Res<UnitQuadMesh>>` / `Option<ResMut<Assets<…>>>` will
+//! receive `None` and fall back to plain [`bevy::sprite::Sprite`] rendering.
+
+use bevy::prelude::*;
+use bevy::render::render_resource::AsBindGroup;
+use bevy::shader::ShaderRef;
+use bevy::sprite_render::{AlphaMode2d, Material2d, Material2dPlugin};
+
+// ---------------------------------------------------------------------------
+// Shader asset paths (relative to the game's `assets/` directory)
+// ---------------------------------------------------------------------------
+
+const SOFT_CIRCLE_SHADER_PATH: &str = "shaders/soft_circle.wgsl";
+const RADIAL_GRADIENT_SHADER_PATH: &str = "shaders/radial_gradient.wgsl";
+const SCREEN_DROPLET_SHADER_PATH: &str = "shaders/screen_droplet.wgsl";
+const WEATHER_POSTPROCESS_SHADER_PATH: &str = "shaders/weather_postprocess.wgsl";
+const RAIN_DROP_SHADER_PATH: &str = "shaders/rain_drop.wgsl";
+const SUN_SHADER_PATH: &str = "shaders/sun.wgsl";
+const CLOUD_PUFF_SHADER_PATH: &str = "shaders/cloud_puff.wgsl";
+
+// ---------------------------------------------------------------------------
+// Material definitions
+// ---------------------------------------------------------------------------
+
+/// Soft-circle material — renders an SDF circle with smooth anti-aliased edges.
+///
+/// Used for [`crate::systems::effects::droplet::WaterDroplet`] particles.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct SoftCircleMaterial {
+    /// RGBA colour in linear space (alpha is faded per-frame by the update system).
+    #[uniform(0)]
+    pub color: LinearRgba,
+}
+
+impl Material2d for SoftCircleMaterial {
+    fn fragment_shader() -> ShaderRef {
+        SOFT_CIRCLE_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+/// Radial-gradient material — bright centre, transparent edge.
+///
+/// Used for [`crate::systems::effects::flash::LocalFlashAnimation`].
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct RadialGradientMaterial {
+    /// RGBA colour in linear space.
+    #[uniform(0)]
+    pub color: LinearRgba,
+}
+
+impl Material2d for RadialGradientMaterial {
+    fn fragment_shader() -> ShaderRef {
+        RADIAL_GRADIENT_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+/// Screen-droplet material — hollow ring with refraction highlight.
+///
+/// Used for [`crate::systems::effects::screen_droplet::ScreenDroplet`].
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct ScreenDropletMaterial {
+    /// RGBA colour in linear space.
+    #[uniform(0)]
+    pub color: LinearRgba,
+}
+
+impl Material2d for ScreenDropletMaterial {
+    fn fragment_shader() -> ShaderRef {
+        SCREEN_DROPLET_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+/// Weather post-process overlay material — full-screen vignette tint.
+///
+/// Used by [`crate::systems::effects::postprocess`].
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct WeatherPostprocessMaterial {
+    /// RGBA tint colour in linear space.
+    #[uniform(0)]
+    pub color: LinearRgba,
+}
+
+impl Material2d for WeatherPostprocessMaterial {
+    fn fragment_shader() -> ShaderRef {
+        WEATHER_POSTPROCESS_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+/// Rain-drop streak material — soft elongated streak with tapered tips and
+/// a subtle centre glow simulating light refraction.
+///
+/// Used for [`crate::systems::effects::rain::RainDrop`] particles.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct RainDropMaterial {
+    /// RGBA colour in linear space.
+    #[uniform(0)]
+    pub color: LinearRgba,
+}
+
+impl Material2d for RainDropMaterial {
+    fn fragment_shader() -> ShaderRef {
+        RAIN_DROP_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+/// Sun disc material — warm glowing disc with animated rotating light rays.
+///
+/// Both fields share binding 0 and are packed into a single WGSL uniform struct:
+/// - `color`: RGBA tint applied to the sun
+/// - `params`: `x` = elapsed time in seconds (drives ray rotation)
+///
+/// Used for [`crate::systems::effects::sun::SunEffect`].
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct SunMaterial {
+    /// RGBA tint colour (rgb multiplied into the warm palette; a = overall opacity).
+    #[uniform(0)]
+    pub color: LinearRgba,
+    /// Shader parameters packed as Vec4.  `x` = elapsed time in seconds.
+    #[uniform(0)]
+    pub params: Vec4,
+}
+
+impl Material2d for SunMaterial {
+    fn fragment_shader() -> ShaderRef {
+        SUN_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+/// Cloud puff material — fluffy SDF cloud shape rendered via smooth-union circles.
+///
+/// Used for [`crate::systems::effects::cloud_effect::CloudPuff`] entities.
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct CloudMaterial {
+    /// RGBA colour in linear space (alpha updated per-frame for edge fading).
+    #[uniform(0)]
+    pub color: LinearRgba,
+}
+
+impl Material2d for CloudMaterial {
+    fn fragment_shader() -> ShaderRef {
+        CLOUD_PUFF_SHADER_PATH.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode2d {
+        AlphaMode2d::Blend
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared mesh-handle resources
+// ---------------------------------------------------------------------------
+
+/// A 1×1 unit quad mesh shared among all shader-based particles.
+///
+/// Inserted by [`ShadersPlugin`] at [`Startup`]. Systems that spawn
+/// shader particles accept `Option<Res<UnitQuadMesh>>` and fall back to
+/// plain [`bevy::sprite::Sprite`] when this resource is absent.
+#[derive(Resource)]
+pub struct UnitQuadMesh(pub Handle<Mesh>);
+
+/// A very large quad used for full-screen overlay effects.
+///
+/// Large enough (20 000 × 20 000 world units) to cover the screen at any
+/// camera zoom used in this game.
+#[derive(Resource)]
+pub struct FullScreenQuadMesh(pub Handle<Mesh>);
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+/// Registers all custom [`Material2d`] types and creates shared mesh resources.
+///
+/// **Must be added after `DefaultPlugins`** because it needs the asset and
+/// render plugins that `DefaultPlugins` provides.
+pub struct ShadersPlugin;
+
+impl Plugin for ShadersPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(Material2dPlugin::<SoftCircleMaterial>::default())
+            .add_plugins(Material2dPlugin::<RadialGradientMaterial>::default())
+            .add_plugins(Material2dPlugin::<ScreenDropletMaterial>::default())
+            .add_plugins(Material2dPlugin::<WeatherPostprocessMaterial>::default())
+            .add_plugins(Material2dPlugin::<RainDropMaterial>::default())
+            .add_plugins(Material2dPlugin::<SunMaterial>::default())
+            .add_plugins(Material2dPlugin::<CloudMaterial>::default())
+            .add_systems(Startup, setup_shared_meshes);
+    }
+}
+
+fn setup_shared_meshes(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
+    // Unit quad: actual size is controlled via Transform::scale at spawn time.
+    let unit = meshes.add(Rectangle::new(1.0, 1.0));
+    commands.insert_resource(UnitQuadMesh(unit));
+
+    // Full-screen quad: large enough for any camera configuration.
+    let full = meshes.add(Rectangle::new(20_000.0, 20_000.0));
+    commands.insert_resource(FullScreenQuadMesh(full));
+}

--- a/app/core/src/systems/effects.rs
+++ b/app/core/src/systems/effects.rs
@@ -5,9 +5,14 @@
 //! and flash effects for merges and landings.
 
 pub mod bounce;
+pub mod cloud_effect;
 pub mod droplet;
 pub mod flash;
+pub mod postprocess;
+pub mod rain;
+pub mod screen_droplet;
 pub mod shake;
+pub mod sun;
 pub mod watermelon;
 
 use bevy::prelude::*;

--- a/app/core/src/systems/effects/cloud_effect.rs
+++ b/app/core/src/systems/effects/cloud_effect.rs
@@ -1,0 +1,254 @@
+//! Drifting cloud puff effect for Cloudy weather.
+//!
+//! Spawns multiple soft cloud blobs — rendered via [`CloudMaterial`] and the
+//! `cloud_puff.wgsl` shader — that drift slowly from right to left across the
+//! upper part of the play field.  Alpha is faded in and out at the horizontal
+//! edges so the transition is invisible even when clouds loop back to the right.
+
+use bevy::prelude::*;
+use rand::RngExt;
+
+use crate::resources::weather::{CurrentWeather, WeatherState};
+use crate::shaders::{CloudMaterial, UnitQuadMesh};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Total number of cloud puff entities kept alive during Cloudy weather.
+pub const MAX_CLOUD_PUFFS: usize = 8;
+/// Minimum leftward drift speed (world units / second).
+pub const CLOUD_SPEED_MIN: f32 = 18.0;
+/// Maximum leftward drift speed (world units / second).
+pub const CLOUD_SPEED_MAX: f32 = 45.0;
+/// X coordinate at which a cloud is (re-)spawned — off the right edge.
+pub const CLOUD_SPAWN_X: f32 = 680.0;
+/// X coordinate below which a cloud wraps back to the right edge.
+pub const CLOUD_DESPAWN_X: f32 = -680.0;
+/// Minimum Y coordinate for cloud placement (world units).
+pub const CLOUD_Y_MIN: f32 = 65.0;
+/// Maximum Y coordinate for cloud placement (world units).
+pub const CLOUD_Y_MAX: f32 = 285.0;
+/// Width of the horizontal fade zone at each screen edge (world units).
+pub const CLOUD_FADE_ZONE: f32 = 130.0;
+/// Minimum cloud quad width (world units).
+pub const CLOUD_WIDTH_MIN: f32 = 185.0;
+/// Maximum cloud quad width (world units).
+pub const CLOUD_WIDTH_MAX: f32 = 275.0;
+/// Height-to-width ratio for cloud quads (clouds are wider than tall).
+pub const CLOUD_HEIGHT_RATIO: f32 = 0.55;
+/// Maximum cloud alpha when fully visible (centre of screen).
+pub const CLOUD_BASE_ALPHA: f32 = 0.68;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/// A single drifting cloud puff entity.
+#[derive(Component)]
+pub struct CloudPuff {
+    /// Leftward drift speed (negative = moves left).
+    pub vel_x: f32,
+    /// Material handle used to update alpha for edge fading.
+    pub material_handle: Handle<CloudMaterial>,
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Spawns the initial set of cloud puffs at the start of a Cloudy session.
+///
+/// Clouds are distributed across the full horizontal range so the screen
+/// does not look empty at the moment of entry.
+///
+/// Run on `OnEnter(AppState::Playing)`.
+pub fn setup_cloud_puffs(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    unit_quad: Option<Res<UnitQuadMesh>>,
+    mut cloud_materials: Option<ResMut<Assets<CloudMaterial>>>,
+) {
+    if weather.state != WeatherState::Cloudy {
+        return;
+    }
+
+    let (Some(quad), Some(mats)) = (unit_quad.as_ref(), cloud_materials.as_mut()) else {
+        // Cloud puffs are shader-only; skip in headless / test contexts.
+        return;
+    };
+
+    let mut rng = rand::rng();
+
+    for i in 0..MAX_CLOUD_PUFFS {
+        // Spread clouds evenly from left to right on first spawn.
+        let x_frac = i as f32 / MAX_CLOUD_PUFFS as f32;
+        let x = CLOUD_DESPAWN_X + (CLOUD_SPAWN_X - CLOUD_DESPAWN_X) * x_frac;
+        let y: f32 = rng.random_range(CLOUD_Y_MIN..CLOUD_Y_MAX);
+
+        let width: f32 = rng.random_range(CLOUD_WIDTH_MIN..CLOUD_WIDTH_MAX);
+        let height = width * CLOUD_HEIGHT_RATIO;
+        let vel_x = -rng.random_range(CLOUD_SPEED_MIN..CLOUD_SPEED_MAX);
+
+        let alpha = edge_alpha(x);
+        let mat = mats.add(CloudMaterial {
+            color: LinearRgba::new(0.96, 0.96, 0.98, alpha),
+        });
+        let mat_handle = mat.clone();
+
+        commands.spawn((
+            CloudPuff {
+                vel_x,
+                material_handle: mat_handle,
+            },
+            Mesh2d(quad.0.clone()),
+            MeshMaterial2d(mat),
+            Transform {
+                translation: Vec3::new(x, y, 1.5),
+                scale: Vec3::new(width, height, 1.0),
+                ..default()
+            },
+        ));
+    }
+
+    info!("Cloud puffs spawned: {}", MAX_CLOUD_PUFFS);
+}
+
+/// Moves clouds leftward and updates alpha for smooth edge fading.
+///
+/// When a cloud exits the left edge it wraps back to the right, creating a
+/// seamless looping effect.  Alpha is continuously re-computed so each cloud
+/// fades in from the right and fades out towards the left.
+///
+/// Run every `Update` while `AppState::Playing`.
+pub fn update_cloud_puffs(
+    mut cloud_query: Query<(&CloudPuff, &mut Transform)>,
+    mut cloud_materials: Option<ResMut<Assets<CloudMaterial>>>,
+    time: Res<Time>,
+) {
+    let Some(ref mut mats) = cloud_materials else {
+        return;
+    };
+    let dt = time.delta_secs();
+
+    for (cloud, mut transform) in cloud_query.iter_mut() {
+        transform.translation.x += cloud.vel_x * dt;
+
+        // Wrap around: reappear from the right when past the left boundary.
+        if transform.translation.x < CLOUD_DESPAWN_X {
+            transform.translation.x = CLOUD_SPAWN_X;
+        }
+
+        // Update material alpha based on screen-edge proximity.
+        let alpha = edge_alpha(transform.translation.x);
+        if let Some(mat) = mats.get_mut(&cloud.material_handle) {
+            mat.color.alpha = alpha;
+        }
+    }
+}
+
+/// Despawns all cloud puff entities when leaving the Playing state.
+///
+/// Run on `OnExit(AppState::Playing)`.
+pub fn despawn_cloud_puffs(mut commands: Commands, cloud_query: Query<Entity, With<CloudPuff>>) {
+    for entity in cloud_query.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the alpha for a cloud at the given x position, fading to zero
+/// near both horizontal edges of the play area.
+fn edge_alpha(x: f32) -> f32 {
+    let right_fade = smoothstep(CLOUD_SPAWN_X, CLOUD_SPAWN_X - CLOUD_FADE_ZONE, x);
+    let left_fade = smoothstep(CLOUD_DESPAWN_X, CLOUD_DESPAWN_X + CLOUD_FADE_ZONE, x);
+    (right_fade * left_fade * CLOUD_BASE_ALPHA).clamp(0.0, CLOUD_BASE_ALPHA)
+}
+
+/// Scalar smoothstep (CPU equivalent of WGSL's `smoothstep`).
+fn smoothstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resources::weather::WeatherState;
+
+    #[test]
+    fn test_setup_cloud_puffs_skips_non_cloudy() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(CurrentWeather {
+            state: WeatherState::Sunny,
+        });
+        app.add_systems(bevy::app::Startup, setup_cloud_puffs);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&CloudPuff>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 0, "No clouds should spawn during non-Cloudy weather");
+    }
+
+    #[test]
+    fn test_despawn_cloud_puffs_removes_entities() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        // Manually insert two fake CloudPuff entities.
+        for _ in 0..2 {
+            app.world_mut().spawn((
+                CloudPuff {
+                    vel_x: -30.0,
+                    material_handle: Handle::default(),
+                },
+                Transform::default(),
+            ));
+        }
+        app.add_systems(Update, despawn_cloud_puffs);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&CloudPuff>()
+            .iter(app.world())
+            .count();
+        assert_eq!(
+            count, 0,
+            "despawn_cloud_puffs should remove all CloudPuff entities"
+        );
+    }
+
+    #[test]
+    fn test_edge_alpha_zero_at_edges() {
+        // Exactly at the spawn/despawn boundaries alpha should be 0.
+        assert!(
+            edge_alpha(CLOUD_SPAWN_X) < 0.01,
+            "Alpha at right spawn edge should be near zero"
+        );
+        assert!(
+            edge_alpha(CLOUD_DESPAWN_X) < 0.01,
+            "Alpha at left despawn edge should be near zero"
+        );
+    }
+
+    #[test]
+    fn test_edge_alpha_max_at_center() {
+        // Alpha near the centre should be close to CLOUD_BASE_ALPHA.
+        let centre_alpha = edge_alpha(0.0);
+        assert!(
+            (centre_alpha - CLOUD_BASE_ALPHA).abs() < 0.01,
+            "Alpha at screen centre should equal CLOUD_BASE_ALPHA"
+        );
+    }
+}

--- a/app/core/src/systems/effects/postprocess.rs
+++ b/app/core/src/systems/effects/postprocess.rs
@@ -1,0 +1,205 @@
+//! Weather post-process overlay system
+//!
+//! Manages the full-screen colour overlay that visually differentiates weather
+//! conditions during gameplay:
+//!
+//! | Weather | Overlay | Bloom |
+//! |---------|---------|-------|
+//! | Sunny   | none (transparent) | on |
+//! | Rainy   | cool blue wash     | off |
+//! | Cloudy  | grey wash          | off |
+//!
+//! The overlay is a large quad at Z = 997 rendered through
+//! [`WeatherPostprocessMaterial`].  Bloom is applied by inserting / removing
+//! the [`Bloom`] component on the camera entity.
+
+use bevy::prelude::*;
+
+use crate::resources::weather::CurrentWeather;
+use crate::shaders::{FullScreenQuadMesh, WeatherPostprocessMaterial};
+
+/// Z layer for the weather overlay (below screen droplets at 998).
+pub const WEATHER_OVERLAY_Z: f32 = 997.0;
+
+// ---------------------------------------------------------------------------
+// Marker component
+// ---------------------------------------------------------------------------
+
+/// Marks the full-screen weather-overlay entity so it can be despawned on exit.
+#[derive(Component)]
+pub struct WeatherOverlay;
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Spawns the weather overlay entity at the start of a play session.
+///
+/// Run on `OnEnter(AppState::Playing)`.
+/// For Sunny weather the overlay colour has alpha=0 so no overlay is spawned.
+pub fn setup_weather_overlay(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    quad: Option<Res<FullScreenQuadMesh>>,
+    mut materials: Option<ResMut<Assets<WeatherPostprocessMaterial>>>,
+) {
+    let params = weather.state.params();
+    let [r, g, b, a] = params.overlay_color;
+
+    // Don't spawn an overlay when alpha is zero (Sunny weather).
+    if a <= 0.0 {
+        return;
+    }
+
+    match (quad.as_ref(), materials.as_mut()) {
+        (Some(quad), Some(mats)) => {
+            let color = LinearRgba::new(r, g, b, a);
+            let mat = mats.add(WeatherPostprocessMaterial { color });
+            commands.spawn((
+                WeatherOverlay,
+                Mesh2d(quad.0.clone()),
+                MeshMaterial2d(mat),
+                Transform::from_translation(Vec3::new(0.0, 0.0, WEATHER_OVERLAY_Z)),
+            ));
+            info!(
+                "WeatherOverlay spawned (shader): weather={:?} rgba=({:.2},{:.2},{:.2},{:.2})",
+                weather.state, r, g, b, a
+            );
+        }
+        _ => {
+            // Sprite fallback (headless / test contexts without ShadersPlugin).
+            commands.spawn((
+                WeatherOverlay,
+                Sprite {
+                    color: Color::srgba(r, g, b, a),
+                    custom_size: Some(Vec2::splat(20_000.0)),
+                    ..default()
+                },
+                Transform::from_translation(Vec3::new(0.0, 0.0, WEATHER_OVERLAY_Z)),
+            ));
+            info!(
+                "WeatherOverlay spawned (sprite fallback): weather={:?} rgba=({:.2},{:.2},{:.2},{:.2})",
+                weather.state, r, g, b, a
+            );
+        }
+    }
+}
+
+/// Despawns the weather overlay when leaving the Playing state.
+///
+/// Run on `OnExit(AppState::Playing)`.
+pub fn despawn_weather_overlay(
+    mut commands: Commands,
+    overlays: Query<Entity, With<WeatherOverlay>>,
+) {
+    for entity in overlays.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+/// Applies or removes camera [`Bloom`] based on the current weather.
+///
+/// Run on `OnEnter(AppState::Playing)`.
+/// Requires Bevy's core-pipeline bloom feature and an HDR-capable camera.
+pub fn apply_weather_bloom(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    cameras: Query<Entity, With<Camera2d>>,
+) {
+    let params = weather.state.params();
+    for camera_entity in cameras.iter() {
+        if params.bloom {
+            commands
+                .entity(camera_entity)
+                .insert(bevy::post_process::bloom::Bloom {
+                    intensity: params.bloom_intensity,
+                    ..default()
+                });
+            info!(
+                "Bloom enabled: weather={:?} intensity={:.2}",
+                weather.state, params.bloom_intensity
+            );
+        } else {
+            commands
+                .entity(camera_entity)
+                .remove::<bevy::post_process::bloom::Bloom>();
+            info!("Bloom disabled: weather={:?}", weather.state);
+        }
+    }
+}
+
+/// Removes camera bloom when leaving the Playing state.
+///
+/// Run on `OnExit(AppState::Playing)`.
+pub fn remove_weather_bloom(mut commands: Commands, cameras: Query<Entity, With<Camera2d>>) {
+    for camera_entity in cameras.iter() {
+        commands
+            .entity(camera_entity)
+            .remove::<bevy::post_process::bloom::Bloom>();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resources::weather::WeatherState;
+
+    #[test]
+    fn test_setup_weather_overlay_sunny_spawns_nothing() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(CurrentWeather {
+            state: WeatherState::Sunny,
+        });
+        app.add_systems(bevy::app::Startup, setup_weather_overlay);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&WeatherOverlay>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 0, "Sunny weather should not spawn any overlay");
+    }
+
+    #[test]
+    fn test_setup_weather_overlay_rainy_spawns_overlay() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(CurrentWeather {
+            state: WeatherState::Rainy,
+        });
+        app.add_systems(bevy::app::Startup, setup_weather_overlay);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&WeatherOverlay>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 1, "Rainy weather should spawn one overlay entity");
+    }
+
+    #[test]
+    fn test_despawn_weather_overlay_removes_entity() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.add_systems(bevy::app::Startup, |mut commands: Commands| {
+            commands.spawn((WeatherOverlay, Sprite::default(), Transform::default()));
+        });
+        app.add_systems(Update, despawn_weather_overlay);
+        app.update(); // Startup
+        app.update(); // Update (runs despawn)
+
+        let count = app
+            .world_mut()
+            .query::<&WeatherOverlay>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 0, "All overlay entities should be despawned");
+    }
+}

--- a/app/core/src/systems/effects/rain.rs
+++ b/app/core/src/systems/effects/rain.rs
@@ -1,0 +1,239 @@
+//! Rain-drop particle system
+//!
+//! Spawns thin diagonal sprite streaks that fall from the top of the screen to
+//! the bottom, simulating rainfall.  Active only when the current weather is
+//! [`WeatherState::Rainy`].
+
+use bevy::prelude::*;
+use rand::RngExt;
+
+use crate::resources::weather::{CurrentWeather, WeatherState};
+use crate::shaders::{RainDropMaterial, UnitQuadMesh};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum simultaneous rain-drop sprites.
+pub const MAX_RAIN_PARTICLES: u32 = 200;
+/// Minimum downward fall speed (world units / second).
+pub const RAIN_SPEED_MIN: f32 = 400.0;
+/// Maximum downward fall speed (world units / second).
+pub const RAIN_SPEED_MAX: f32 = 600.0;
+/// Minimum horizontal wind speed (consistently leftward for realism).
+pub const RAIN_WIND_MIN: f32 = -110.0;
+/// Maximum horizontal wind speed (mostly leftward, slight variation).
+pub const RAIN_WIND_MAX: f32 = -20.0;
+/// Y coordinate at which drops are spawned (above the visible area).
+pub const RAIN_SPAWN_Y: f32 = 340.0;
+/// Y coordinate at which drops are despawned (below the visible area).
+pub const RAIN_DESPAWN_Y: f32 = -340.0;
+/// Half-width of the horizontal spawn zone.
+pub const RAIN_SPAWN_X_HALF: f32 = 450.0;
+/// Sprite width (thin streak).
+pub const RAIN_WIDTH: f32 = 2.0;
+/// Sprite height (long enough to read as a streak).
+pub const RAIN_HEIGHT: f32 = 28.0;
+/// Rain-drop base colour — translucent light blue (alpha is randomised per drop).
+pub const RAIN_COLOR_BASE: Color = Color::srgb(0.72, 0.84, 0.97);
+/// Minimum per-drop alpha (far/background drops).
+pub const RAIN_ALPHA_MIN: f32 = 0.25;
+/// Maximum per-drop alpha (near/foreground drops).
+pub const RAIN_ALPHA_MAX: f32 = 0.65;
+/// Number of drops spawned per frame when filling up to [`MAX_RAIN_PARTICLES`].
+pub const RAIN_BATCH_SPAWN: u32 = 5;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/// A single rain-drop sprite.
+///
+/// The sprite is a thin rotated quad that moves at a constant velocity.
+/// When it leaves [`RAIN_DESPAWN_Y`] it is despawned and a new one will be
+/// spawned by [`spawn_rain`] on the next frame.
+#[derive(Component, Debug)]
+pub struct RainDrop {
+    /// Horizontal velocity (wind offset), in world units / second.
+    pub vel_x: f32,
+    /// Vertical velocity (always negative — downward), in world units / second.
+    pub vel_y: f32,
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Fills rain particles up to [`MAX_RAIN_PARTICLES`] when weather is Rainy.
+///
+/// Each drop is rendered as a soft-edged streak via [`RainDropMaterial`] when
+/// the shader system is available, falling back to a plain [`Sprite`] otherwise.
+pub fn spawn_rain(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    existing: Query<(), With<RainDrop>>,
+    unit_quad: Option<Res<UnitQuadMesh>>,
+    mut rain_materials: Option<ResMut<Assets<RainDropMaterial>>>,
+) {
+    if weather.state != WeatherState::Rainy {
+        return;
+    }
+
+    let current_count = existing.iter().count() as u32;
+    let max = weather.state.params().max_rain_particles;
+    if current_count >= max {
+        return;
+    }
+
+    let to_spawn = (max - current_count).min(RAIN_BATCH_SPAWN);
+    let mut rng = rand::rng();
+
+    for _ in 0..to_spawn {
+        let x: f32 = rng.random_range(-RAIN_SPAWN_X_HALF..RAIN_SPAWN_X_HALF);
+        let vel_y = -rng.random_range(RAIN_SPEED_MIN..RAIN_SPEED_MAX);
+        let vel_x = rng.random_range(RAIN_WIND_MIN..RAIN_WIND_MAX);
+
+        // Tilt sprite/mesh to match the actual fall direction
+        let angle = (vel_x / vel_y.abs()).atan();
+
+        // Spread initial Y so the screen fills immediately on session start
+        let y: f32 = rng.random_range(RAIN_DESPAWN_Y..RAIN_SPAWN_Y);
+
+        // Per-drop alpha variation gives depth (far drops are more transparent)
+        let alpha = rng.random_range(RAIN_ALPHA_MIN..RAIN_ALPHA_MAX);
+
+        let transform = Transform {
+            translation: Vec3::new(x, y, 3.0),
+            rotation: Quat::from_rotation_z(angle),
+            scale: Vec3::new(RAIN_WIDTH, RAIN_HEIGHT, 1.0),
+        };
+
+        match (unit_quad.as_ref(), rain_materials.as_mut()) {
+            (Some(quad), Some(mats)) => {
+                // Shader path: soft-edged streak with centre glow
+                let color = LinearRgba::new(0.72, 0.84, 0.97, alpha);
+                let mat = mats.add(RainDropMaterial { color });
+                commands.spawn((
+                    RainDrop { vel_x, vel_y },
+                    Mesh2d(quad.0.clone()),
+                    MeshMaterial2d(mat),
+                    transform,
+                ));
+            }
+            _ => {
+                // Sprite fallback (headless / test contexts without ShadersPlugin)
+                commands.spawn((
+                    RainDrop { vel_x, vel_y },
+                    Sprite {
+                        color: RAIN_COLOR_BASE.with_alpha(alpha),
+                        custom_size: Some(Vec2::new(RAIN_WIDTH, RAIN_HEIGHT)),
+                        ..default()
+                    },
+                    Transform {
+                        translation: transform.translation,
+                        rotation: transform.rotation,
+                        ..default()
+                    },
+                ));
+            }
+        }
+    }
+}
+
+/// Advances rain particles and despawns those that leave the visible area.
+pub fn update_rain(
+    mut commands: Commands,
+    mut drops: Query<(Entity, &RainDrop, &mut Transform)>,
+    time: Res<Time>,
+) {
+    let dt = time.delta_secs();
+    for (entity, drop, mut transform) in drops.iter_mut() {
+        transform.translation.x += drop.vel_x * dt;
+        transform.translation.y += drop.vel_y * dt;
+
+        if transform.translation.y < RAIN_DESPAWN_Y {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Despawns all rain particles when weather is no longer [`WeatherState::Rainy`].
+pub fn cleanup_rain_on_weather_change(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    drops: Query<Entity, With<RainDrop>>,
+) {
+    if weather.state == WeatherState::Rainy {
+        return;
+    }
+    for entity in drops.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rain_speed_range_valid() {
+        assert!(
+            RAIN_SPEED_MIN < RAIN_SPEED_MAX,
+            "Min speed must be less than max speed"
+        );
+    }
+
+    #[test]
+    fn test_rain_wind_range_valid() {
+        assert!(
+            RAIN_WIND_MIN < RAIN_WIND_MAX,
+            "Min wind must be less than max wind"
+        );
+    }
+
+    #[test]
+    fn test_rain_spawn_y_above_despawn_y() {
+        assert!(
+            RAIN_SPAWN_Y > RAIN_DESPAWN_Y,
+            "Spawn Y must be above despawn Y"
+        );
+    }
+
+    #[test]
+    fn test_spawn_rain_only_when_rainy() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.init_resource::<CurrentWeather>(); // Defaults to Sunny
+        app.add_systems(Update, spawn_rain);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&RainDrop>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 0, "No rain should spawn during Sunny weather");
+    }
+
+    #[test]
+    fn test_spawn_rain_spawns_when_rainy() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(CurrentWeather {
+            state: WeatherState::Rainy,
+        });
+        app.add_systems(Update, spawn_rain);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&RainDrop>()
+            .iter(app.world())
+            .count();
+        assert!(count > 0, "Rain should spawn during Rainy weather");
+    }
+}

--- a/app/core/src/systems/effects/screen_droplet.rs
+++ b/app/core/src/systems/effects/screen_droplet.rs
@@ -1,0 +1,297 @@
+//! Screen-droplet overlay effect
+//!
+//! Spawns large translucent water-droplet shapes on the overlay layer (Z ≈ 998)
+//! that simulate droplets on the camera lens.  Each drop slides slowly
+//! downward and fades out at the end of its lifetime.
+//!
+//! **Triggers:**
+//! - A large-fruit merge (Peach or above) → a small burst of drops.
+//! - [`WeatherState::Rainy`] → drops spawn periodically throughout the session.
+
+use bevy::prelude::*;
+use rand::RngExt;
+
+use crate::events::FruitMergeEvent;
+use crate::resources::weather::{CurrentWeather, WeatherState};
+use crate::shaders::{ScreenDropletMaterial, UnitQuadMesh};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Hard cap on simultaneous screen droplets.
+pub const MAX_SCREEN_DROPLETS: u32 = 30;
+/// Minimum fruit stage index (0-based) that triggers screen droplets on merge.
+/// `7` = Peach (Cherry=0, …, Peach=7, Pineapple=8, …).
+pub const SCREEN_DROPLET_MIN_STAGE: usize = 7;
+/// Droplets spawned per qualifying merge event.
+pub const SCREEN_DROPLETS_PER_MERGE: u32 = 3;
+/// Visual radius of each screen droplet (world units).
+pub const SCREEN_DROPLET_RADIUS: f32 = 28.0;
+/// Minimum slide-down speed (world units / second).
+pub const SCREEN_DROPLET_SPEED_MIN: f32 = 30.0;
+/// Maximum slide-down speed (world units / second).
+pub const SCREEN_DROPLET_SPEED_MAX: f32 = 70.0;
+/// Minimum droplet lifetime before despawn (seconds).
+pub const SCREEN_DROPLET_LIFETIME_MIN: f32 = 3.0;
+/// Maximum droplet lifetime before despawn (seconds).
+pub const SCREEN_DROPLET_LIFETIME_MAX: f32 = 6.0;
+/// Half-width of the screen area where droplets are placed.
+pub const SCREEN_DROPLET_X_HALF: f32 = 360.0;
+/// Y coordinate at which droplets are initially placed.
+pub const SCREEN_DROPLET_SPAWN_Y: f32 = 250.0;
+/// Z layer for screen droplets (just below the screen-flash overlay at 999).
+pub const SCREEN_DROPLET_Z: f32 = 998.0;
+/// Base RGBA colour for screen droplets (semi-transparent white-blue).
+pub const SCREEN_DROPLET_COLOR: [f32; 4] = [0.82, 0.92, 1.0, 0.85];
+
+// ---------------------------------------------------------------------------
+// Component / Resource
+// ---------------------------------------------------------------------------
+
+/// A water droplet on the "camera lens" overlay layer.
+#[derive(Component, Debug)]
+pub struct ScreenDroplet {
+    /// Downward slide speed (world units / second).
+    pub speed_y: f32,
+    /// Elapsed time since spawn (seconds).
+    pub lifetime: f32,
+    /// Total lifetime before despawn (seconds).
+    pub max_lifetime: f32,
+    /// Current alpha value (updated each frame by the update system).
+    pub alpha: f32,
+}
+
+/// Accumulates time for the rain-weather screen-droplet rate limiter.
+#[derive(Resource, Default)]
+pub struct ScreenDropletSpawnTimer {
+    /// Accumulated seconds since the last screen-droplet spawn burst.
+    pub elapsed: f32,
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Spawns screen droplets when a large fruit (Peach or above) is merged.
+pub fn spawn_screen_droplets_on_merge(
+    mut commands: Commands,
+    mut merge_events: MessageReader<FruitMergeEvent>,
+    existing: Query<(), With<ScreenDroplet>>,
+    unit_quad: Option<Res<UnitQuadMesh>>,
+    mut materials: Option<ResMut<Assets<ScreenDropletMaterial>>>,
+) {
+    let current_count = existing.iter().count() as u32;
+    if current_count >= MAX_SCREEN_DROPLETS {
+        return;
+    }
+
+    for event in merge_events.read() {
+        if event.fruit_type.stage_index() < SCREEN_DROPLET_MIN_STAGE {
+            continue;
+        }
+        let remaining = MAX_SCREEN_DROPLETS - current_count;
+        let count = SCREEN_DROPLETS_PER_MERGE.min(remaining);
+        spawn_n_screen_droplets(&mut commands, count, &unit_quad, &mut materials);
+    }
+}
+
+/// Spawns screen droplets periodically during rainy weather.
+pub fn spawn_screen_droplets_rain(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    mut timer: ResMut<ScreenDropletSpawnTimer>,
+    time: Res<Time>,
+    existing: Query<(), With<ScreenDroplet>>,
+    unit_quad: Option<Res<UnitQuadMesh>>,
+    mut materials: Option<ResMut<Assets<ScreenDropletMaterial>>>,
+) {
+    if weather.state != WeatherState::Rainy {
+        timer.elapsed = 0.0;
+        return;
+    }
+
+    let current_count = existing.iter().count() as u32;
+    if current_count >= MAX_SCREEN_DROPLETS {
+        return;
+    }
+
+    let rate = weather.state.params().screen_droplet_rate;
+    if rate <= 0.0 {
+        return;
+    }
+
+    timer.elapsed += time.delta_secs();
+    let interval = 1.0 / rate;
+    if timer.elapsed < interval {
+        return;
+    }
+    timer.elapsed -= interval;
+
+    spawn_n_screen_droplets(&mut commands, 1, &unit_quad, &mut materials);
+}
+
+/// Advances droplets: slides them down, fades the tail end, and despawns them.
+pub fn update_screen_droplets(
+    mut commands: Commands,
+    mut droplets: Query<(Entity, &mut ScreenDroplet, &mut Transform)>,
+    time: Res<Time>,
+) {
+    let dt = time.delta_secs();
+    for (entity, mut droplet, mut transform) in droplets.iter_mut() {
+        transform.translation.y -= droplet.speed_y * dt;
+        droplet.lifetime += dt;
+
+        // Fade out during the last 20 % of the lifetime.
+        let progress = if droplet.max_lifetime > 0.0 {
+            (droplet.lifetime / droplet.max_lifetime).clamp(0.0, 1.0)
+        } else {
+            1.0
+        };
+        droplet.alpha = if progress > 0.8 {
+            SCREEN_DROPLET_COLOR[3] * ((1.0 - progress) / 0.2)
+        } else {
+            SCREEN_DROPLET_COLOR[3]
+        };
+
+        if droplet.lifetime >= droplet.max_lifetime {
+            commands.entity(entity).despawn();
+        }
+    }
+}
+
+/// Syncs screen-droplet alpha to `Sprite` (fallback / headless mode).
+pub fn sync_screen_droplet_sprite_alpha(
+    mut droplets: Query<
+        (&ScreenDroplet, &mut Sprite),
+        Without<MeshMaterial2d<ScreenDropletMaterial>>,
+    >,
+) {
+    for (droplet, mut sprite) in droplets.iter_mut() {
+        sprite.color = sprite.color.with_alpha(droplet.alpha);
+    }
+}
+
+/// Syncs screen-droplet alpha to [`ScreenDropletMaterial`] (shader mode).
+pub fn sync_screen_droplet_material_alpha(
+    droplets: Query<(&ScreenDroplet, &MeshMaterial2d<ScreenDropletMaterial>)>,
+    mut materials: Option<ResMut<Assets<ScreenDropletMaterial>>>,
+) {
+    let Some(ref mut mats) = materials else {
+        return;
+    };
+    for (droplet, handle) in droplets.iter() {
+        if let Some(mat) = mats.get_mut(&handle.0) {
+            mat.color.alpha = droplet.alpha;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper
+// ---------------------------------------------------------------------------
+
+fn spawn_n_screen_droplets(
+    commands: &mut Commands,
+    count: u32,
+    unit_quad: &Option<Res<UnitQuadMesh>>,
+    materials: &mut Option<ResMut<Assets<ScreenDropletMaterial>>>,
+) {
+    let mut rng = rand::rng();
+    let diameter = SCREEN_DROPLET_RADIUS * 2.0;
+
+    for _ in 0..count {
+        let x: f32 = rng.random_range(-SCREEN_DROPLET_X_HALF..SCREEN_DROPLET_X_HALF);
+        let y: f32 = rng.random_range((SCREEN_DROPLET_SPAWN_Y - 40.0)..SCREEN_DROPLET_SPAWN_Y);
+        let speed_y = rng.random_range(SCREEN_DROPLET_SPEED_MIN..SCREEN_DROPLET_SPEED_MAX);
+        let max_lifetime =
+            rng.random_range(SCREEN_DROPLET_LIFETIME_MIN..SCREEN_DROPLET_LIFETIME_MAX);
+
+        let droplet = ScreenDroplet {
+            speed_y,
+            lifetime: 0.0,
+            max_lifetime,
+            alpha: SCREEN_DROPLET_COLOR[3],
+        };
+
+        match (unit_quad.as_ref(), materials.as_mut()) {
+            (Some(quad), Some(mats)) => {
+                let color = LinearRgba::new(
+                    SCREEN_DROPLET_COLOR[0],
+                    SCREEN_DROPLET_COLOR[1],
+                    SCREEN_DROPLET_COLOR[2],
+                    SCREEN_DROPLET_COLOR[3],
+                );
+                let mat = mats.add(ScreenDropletMaterial { color });
+                commands.spawn((
+                    droplet,
+                    Mesh2d(quad.0.clone()),
+                    MeshMaterial2d(mat),
+                    Transform::from_translation(Vec3::new(x, y, SCREEN_DROPLET_Z))
+                        .with_scale(Vec3::splat(diameter)),
+                ));
+            }
+            _ => {
+                // Sprite fallback (test / headless mode)
+                commands.spawn((
+                    droplet,
+                    Sprite {
+                        color: Color::srgba(
+                            SCREEN_DROPLET_COLOR[0],
+                            SCREEN_DROPLET_COLOR[1],
+                            SCREEN_DROPLET_COLOR[2],
+                            SCREEN_DROPLET_COLOR[3],
+                        ),
+                        custom_size: Some(Vec2::splat(diameter)),
+                        ..default()
+                    },
+                    Transform::from_translation(Vec3::new(x, y, SCREEN_DROPLET_Z)),
+                ));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fruit::FruitType;
+
+    #[test]
+    fn test_screen_droplet_min_stage_is_peach() {
+        // Peach is the 8th fruit (stage index 7, 0-based).
+        assert_eq!(
+            FruitType::Peach.stage_index(),
+            7,
+            "Peach should be stage index 7"
+        );
+        assert!(
+            FruitType::Peach.stage_index() >= SCREEN_DROPLET_MIN_STAGE,
+            "Peach should trigger screen droplets"
+        );
+        assert!(
+            FruitType::Pear.stage_index() < SCREEN_DROPLET_MIN_STAGE,
+            "Pear should NOT trigger screen droplets"
+        );
+    }
+
+    #[test]
+    fn test_screen_droplet_lifetime_range() {
+        assert!(
+            SCREEN_DROPLET_LIFETIME_MIN < SCREEN_DROPLET_LIFETIME_MAX,
+            "Min lifetime must be less than max"
+        );
+    }
+
+    #[test]
+    fn test_screen_droplet_speed_range() {
+        assert!(
+            SCREEN_DROPLET_SPEED_MIN < SCREEN_DROPLET_SPEED_MAX,
+            "Min speed must be less than max"
+        );
+    }
+}

--- a/app/core/src/systems/effects/sun.rs
+++ b/app/core/src/systems/effects/sun.rs
@@ -1,0 +1,154 @@
+//! Animated sun disc for Sunny weather.
+//!
+//! Spawns a warm glowing sun in the upper-right area of the play field when
+//! the weather is [`WeatherState::Sunny`].  The disc is rendered through
+//! [`SunMaterial`] and its light rays rotate slowly via an elapsed-time
+//! uniform updated each frame.
+
+use bevy::prelude::*;
+
+use crate::resources::weather::{CurrentWeather, WeatherState};
+use crate::shaders::{SunMaterial, UnitQuadMesh};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// World-space centre of the sun disc (upper-right, behind the container).
+pub const SUN_POSITION: Vec3 = Vec3::new(250.0, 255.0, 2.0);
+/// Side length of the sun quad in world units.
+pub const SUN_SIZE: f32 = 210.0;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/// Marks the sun entity and stores its material handle for per-frame updates.
+#[derive(Component)]
+pub struct SunEffect {
+    /// Handle used to update `params.x` (elapsed time) each frame.
+    pub material_handle: Handle<SunMaterial>,
+}
+
+// ---------------------------------------------------------------------------
+// Systems
+// ---------------------------------------------------------------------------
+
+/// Spawns the animated sun disc at the start of a Sunny play session.
+///
+/// Run on `OnEnter(AppState::Playing)`.
+/// Does nothing when the weather is not Sunny or when shaders are unavailable.
+pub fn setup_sun(
+    mut commands: Commands,
+    weather: Res<CurrentWeather>,
+    unit_quad: Option<Res<UnitQuadMesh>>,
+    mut sun_materials: Option<ResMut<Assets<SunMaterial>>>,
+) {
+    if weather.state != WeatherState::Sunny {
+        return;
+    }
+
+    match (unit_quad.as_ref(), sun_materials.as_mut()) {
+        (Some(quad), Some(mats)) => {
+            let mat = mats.add(SunMaterial {
+                color: LinearRgba::new(1.0, 0.95, 0.70, 0.90),
+                params: Vec4::ZERO,
+            });
+            let mat_handle = mat.clone();
+            commands.spawn((
+                SunEffect {
+                    material_handle: mat_handle,
+                },
+                Mesh2d(quad.0.clone()),
+                MeshMaterial2d(mat),
+                Transform {
+                    translation: SUN_POSITION,
+                    scale: Vec3::new(SUN_SIZE, SUN_SIZE, 1.0),
+                    ..default()
+                },
+            ));
+            info!("Sun spawned at position {:?}", SUN_POSITION);
+        }
+        _ => {
+            // Sun is a shader-only effect; skip in headless / test contexts.
+        }
+    }
+}
+
+/// Updates `SunMaterial.params.x` each frame so the light rays rotate.
+///
+/// Run every `Update` while `AppState::Playing`.
+pub fn animate_sun(
+    sun_query: Query<&SunEffect>,
+    mut sun_materials: Option<ResMut<Assets<SunMaterial>>>,
+    time: Res<Time>,
+) {
+    let Some(ref mut mats) = sun_materials else {
+        return;
+    };
+    let elapsed = time.elapsed_secs();
+    for sun_effect in sun_query.iter() {
+        if let Some(mat) = mats.get_mut(&sun_effect.material_handle) {
+            mat.params.x = elapsed;
+        }
+    }
+}
+
+/// Despawns all sun entities when leaving the Playing state.
+///
+/// Run on `OnExit(AppState::Playing)`.
+pub fn despawn_sun(mut commands: Commands, sun_query: Query<Entity, With<SunEffect>>) {
+    for entity in sun_query.iter() {
+        commands.entity(entity).despawn();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resources::weather::WeatherState;
+
+    #[test]
+    fn test_setup_sun_skips_non_sunny() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        app.insert_resource(CurrentWeather {
+            state: WeatherState::Rainy,
+        });
+        app.add_systems(bevy::app::Startup, setup_sun);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&SunEffect>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 0, "No sun should spawn during non-Sunny weather");
+    }
+
+    #[test]
+    fn test_despawn_sun_removes_entities() {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins);
+        // Manually insert a fake SunEffect entity (no shader needed)
+        app.world_mut().spawn((
+            SunEffect {
+                material_handle: Handle::default(),
+            },
+            Transform::default(),
+        ));
+        app.add_systems(Update, despawn_sun);
+        app.update();
+
+        let count = app
+            .world_mut()
+            .query::<&SunEffect>()
+            .iter(app.world())
+            .count();
+        assert_eq!(count, 0, "despawn_sun should remove all SunEffect entities");
+    }
+}

--- a/app/suika-game/assets/shaders/cloud_puff.wgsl
+++ b/app/suika-game/assets/shaders/cloud_puff.wgsl
@@ -1,0 +1,64 @@
+// Cloud puff fragment shader
+//
+// Renders a fluffy cumulus-style cloud using smooth union of multiple SDF
+// circles.  The resulting shape has a flat bottom and bumpy rounded top,
+// matching the classic cartoon-cloud silhouette.
+//
+// Shape layout (UV space, y-up):
+//
+//       (o)  (o)
+//      ( O  O  O )
+//       (  base  )
+//
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct CloudMaterial {
+    color: vec4<f32>,
+}
+
+@group(2) @binding(0)
+var<uniform> material: CloudMaterial;
+
+// Smooth minimum — blends two SDF distances for a organic union.
+fn smin(a: f32, b: f32, k: f32) -> f32 {
+    let h = clamp(0.5 + 0.5 * (b - a) / k, 0.0, 1.0);
+    return mix(b, a, h) - k * h * (1.0 - h);
+}
+
+// Signed distance from point `p` to a circle centred at `center` with
+// the given `radius`.  Negative = inside, positive = outside.
+fn circle_sdf(p: vec2<f32>, center: vec2<f32>, radius: f32) -> f32 {
+    return length(p - center) - radius;
+}
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    // Remap UV [0,1] -> centred [-1, 1]
+    let uv = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+
+    // Correct for the cloud quad's aspect ratio (width : height ≈ 1.82)
+    // so that circle_sdf produces round blobs in screen space.
+    let aspect = 1.82;
+    let p = vec2<f32>(uv.x, uv.y * aspect);
+
+    // --- Cloud silhouette: six overlapping SDF circles ---
+    //
+    // Wide, flat base + three dome bumps across the top.
+    var d = circle_sdf(p, vec2<f32>( 0.00, -0.28), 0.60); // wide flat base
+    d = smin(d, circle_sdf(p, vec2<f32>(-0.42,  0.03), 0.34), 0.20); // left mid
+    d = smin(d, circle_sdf(p, vec2<f32>( 0.42,  0.00), 0.36), 0.20); // right mid
+    d = smin(d, circle_sdf(p, vec2<f32>( 0.05,  0.30), 0.42), 0.22); // top centre dome
+    d = smin(d, circle_sdf(p, vec2<f32>(-0.25,  0.38), 0.26), 0.17); // top-left bump
+    d = smin(d, circle_sdf(p, vec2<f32>( 0.32,  0.35), 0.28), 0.17); // top-right bump
+
+    // Soft edge: opaque well inside, transparent outside, smooth transition.
+    let alpha = (1.0 - smoothstep(-0.04, 0.12, d)) * material.color.a;
+
+    // Subtle interior brightness to give a fluffy, volumetric feel.
+    let interior_t  = clamp(-d / 0.5, 0.0, 1.0);
+    let brightness  = 1.0 + interior_t * 0.10;
+    let rgb         = min(material.color.rgb * brightness, vec3<f32>(1.0));
+
+    return vec4<f32>(rgb, clamp(alpha, 0.0, 1.0));
+}

--- a/app/suika-game/assets/shaders/radial_gradient.wgsl
+++ b/app/suika-game/assets/shaders/radial_gradient.wgsl
@@ -1,0 +1,24 @@
+// Radial gradient fragment shader
+//
+// Bright centre that fades to transparent at the edges.
+// Used for LocalFlash merge effects (replaces the flat-colour sprite).
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct RadialGradientMaterial {
+    color: vec4<f32>,
+};
+
+@group(2) @binding(0)
+var<uniform> material: RadialGradientMaterial;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    let uv   = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+    let dist = length(uv); // 0 at centre, 1 at edge
+
+    // Radial gradient: full opacity at centre, transparent at edge
+    let gradient = 1.0 - smoothstep(0.0, 1.0, dist);
+
+    return vec4<f32>(material.color.rgb, material.color.a * gradient);
+}

--- a/app/suika-game/assets/shaders/rain_drop.wgsl
+++ b/app/suika-game/assets/shaders/rain_drop.wgsl
@@ -1,0 +1,43 @@
+// Rain-drop streak fragment shader
+//
+// Renders a soft elongated streak that simulates a falling rain drop.
+// Features:
+//   - Horizontal: Gaussian-like falloff (very narrow, no hard edges)
+//   - Vertical: bright at centre, fades to transparent at both tips
+//   - Centre glow: subtle brightness boost to simulate light refraction
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct RainDropMaterial {
+    color: vec4<f32>,
+};
+
+@group(2) @binding(0)
+var<uniform> material: RainDropMaterial;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    // Remap UV [0,1] -> centred [-1, 1]
+    let uv = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+
+    // ---- Horizontal (across the streak width) ----
+    // Aggressive smoothstep: opaque only very near the centre line
+    let x_fade = 1.0 - smoothstep(0.0, 1.0, abs(uv.x) * 3.5);
+
+    // ---- Vertical (along the streak length) ----
+    // Full opacity in the middle 50%, taper to transparent at both tips
+    let y_fade = 1.0 - smoothstep(0.5, 1.0, abs(uv.y));
+
+    // ---- Combined streak shape ----
+    let streak = x_fade * y_fade;
+
+    // ---- Centre glow: simulate light refraction through water ----
+    // A narrow bright line down the centre of the streak
+    let centre_glow = clamp(1.0 - abs(uv.x) * 5.0, 0.0, 1.0) * 0.35;
+    let brightness   = 1.0 + centre_glow;
+
+    let alpha = clamp(streak, 0.0, 1.0) * material.color.a;
+    let rgb   = min(material.color.rgb * brightness, vec3<f32>(1.0));
+
+    return vec4<f32>(rgb, alpha);
+}

--- a/app/suika-game/assets/shaders/screen_droplet.wgsl
+++ b/app/suika-game/assets/shaders/screen_droplet.wgsl
@@ -1,0 +1,37 @@
+// Screen-droplet fragment shader
+//
+// Renders a translucent water-drop blob that simulates a droplet on the camera
+// lens.  Uses a hollow ring with a bright highlight to suggest light refraction
+// through a water surface.
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct ScreenDropletMaterial {
+    color: vec4<f32>,
+};
+
+@group(2) @binding(0)
+var<uniform> material: ScreenDropletMaterial;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    let uv   = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+    let dist = length(uv);
+
+    // Outer soft boundary
+    let outer = 1.0 - smoothstep(0.75, 1.0, dist);
+    // Inner transparent hole (gives hollow-droplet appearance)
+    let inner = smoothstep(0.35, 0.55, dist);
+    let ring  = outer * inner;
+
+    // Small bright highlight at top-left (simulates light refraction)
+    let hl_pos  = uv - vec2<f32>(-0.35, 0.35);
+    let hl_dist = length(hl_pos);
+    let highlight = (1.0 - smoothstep(0.0, 0.25, hl_dist)) * 0.45;
+
+    let alpha = clamp(ring * 0.55 + highlight, 0.0, 1.0) * material.color.a;
+
+    // Slightly brighten the highlight region
+    let hl_bright = material.color.rgb + vec3<f32>(0.12, 0.12, 0.12) * highlight;
+    return vec4<f32>(hl_bright, alpha);
+}

--- a/app/suika-game/assets/shaders/soft_circle.wgsl
+++ b/app/suika-game/assets/shaders/soft_circle.wgsl
@@ -1,0 +1,26 @@
+// Soft-circle SDF fragment shader
+//
+// Renders a filled circle with smooth anti-aliased edges using a signed-distance
+// function.  Used for WaterDroplet particles instead of hard-edged sprites.
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct SoftCircleMaterial {
+    color: vec4<f32>,
+};
+
+@group(2) @binding(0)
+var<uniform> material: SoftCircleMaterial;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    // Map UV [0,1] to centred coordinates: 0 at centre, 1 at edge
+    let uv  = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+    let dist = length(uv);
+
+    // SDF soft-circle: smooth falloff near the circumference
+    let softness = 0.25;
+    let alpha    = 1.0 - smoothstep(1.0 - softness, 1.0 + softness, dist);
+
+    return vec4<f32>(material.color.rgb, material.color.a * alpha);
+}

--- a/app/suika-game/assets/shaders/sun.wgsl
+++ b/app/suika-game/assets/shaders/sun.wgsl
@@ -1,0 +1,52 @@
+// Sun shader
+//
+// Renders a warm glowing sun disc with:
+//   - Bright core with inner radiance
+//   - Soft outer halo that fades to transparent
+//   - Eight light rays that rotate slowly over time
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct SunMaterial {
+    color: vec4<f32>,
+    // params.x = elapsed time in seconds (for ray rotation)
+    // params.yzw = unused padding
+    params: vec4<f32>,
+}
+
+@group(2) @binding(0) var<uniform> material: SunMaterial;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    let uv   = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+    let dist = length(uv);
+    let t    = material.params.x;
+
+    // --- Core disc ---
+    let core = 1.0 - smoothstep(0.22, 0.27, dist);
+
+    // Extra brightness at the very centre
+    let centre_radiance = (1.0 - smoothstep(0.0, 0.22, dist)) * 0.55;
+
+    // --- Outer halo --- fades from disc edge to transparent
+    let halo = (1.0 - smoothstep(0.27, 1.05, dist)) * 0.55 * max(0.0, 1.0 - dist);
+
+    // --- Rotating light rays (8 spokes) ---
+    let angle    = atan2(uv.y, uv.x) + t * 0.18;
+    let ray_ring = smoothstep(0.27, 0.38, dist) * (1.0 - smoothstep(0.38, 0.92, dist));
+    let rays     = max(0.0, cos(angle * 8.0)) * ray_ring * 0.42;
+
+    // --- Secondary thin rays between main rays ---
+    let thin_rays = max(0.0, cos(angle * 8.0 + 3.14159 / 8.0)) * ray_ring * 0.18;
+
+    let raw_alpha = clamp(core + centre_radiance + halo + rays + thin_rays, 0.0, 1.0);
+    let alpha     = raw_alpha * material.color.a;
+
+    // Warm golden colour at the core, slightly cooler at halo edges
+    let warm_core = vec3<f32>(1.00, 0.95, 0.60);
+    let warm_halo = vec3<f32>(1.00, 0.80, 0.30);
+    let t_edge    = clamp(dist / 1.05, 0.0, 1.0);
+    let base_rgb  = mix(warm_core, warm_halo, t_edge) * material.color.rgb;
+
+    return vec4<f32>(min(base_rgb, vec3<f32>(1.0)), alpha);
+}

--- a/app/suika-game/assets/shaders/weather_postprocess.wgsl
+++ b/app/suika-game/assets/shaders/weather_postprocess.wgsl
@@ -1,0 +1,26 @@
+// Weather post-process overlay shader
+//
+// Draws a full-screen colour vignette tinted by the current weather state.
+//   Sunny  -> transparent (no overlay spawned)
+//   Rainy  -> cool blue tint with soft vignette
+//   Cloudy -> desaturated grey wash with soft vignette
+
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct WeatherPostprocessMaterial {
+    color: vec4<f32>,
+};
+
+@group(2) @binding(0)
+var<uniform> material: WeatherPostprocessMaterial;
+
+@fragment
+fn fragment(mesh: VertexOutput) -> @location(0) vec4<f32> {
+    let uv = mesh.uv * 2.0 - vec2<f32>(1.0, 1.0);
+
+    // Soft vignette: slightly more opaque at the edges
+    let vignette = 1.0 - dot(uv * 0.45, uv * 0.45);
+    let alpha    = material.color.a * max(0.0, vignette);
+
+    return vec4<f32>(material.color.rgb, alpha);
+}

--- a/app/suika-game/src/main.rs
+++ b/app/suika-game/src/main.rs
@@ -20,6 +20,9 @@ fn main() {
             ..default()
         }))
         .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(100.0))
+        // ShadersPlugin must come before GameCorePlugin so that Material2d
+        // types are registered before any systems try to access their assets.
+        .add_plugins(ShadersPlugin)
         .add_plugins(GameAssetsPlugin)
         .add_plugins(GameConfigPlugin)
         .add_plugins(GameCorePlugin)

--- a/app/ui/src/camera.rs
+++ b/app/ui/src/camera.rs
@@ -15,9 +15,13 @@ use suika_game_core::prelude::CameraShake;
 ///
 /// A [`CameraShake`] component is attached so that the core shake system can
 /// apply trauma-based offsets to this camera when fruits merge.
+///
+/// Bloom support: the [`bevy::post_process::bloom::Bloom`] component is added
+/// and removed dynamically by the postprocess system based on [`CurrentWeather`].
 pub fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
+        Camera::default(),
         Transform::from_xyz(0.0, 0.0, 999.9),
         Projection::Orthographic(OrthographicProjection {
             scale: 1.0,


### PR DESCRIPTION
## 概要

Issue #135 の対応として、天気システムと WGSL シェーダーを用いたビジュアルエフェクト基盤を実装しました。
プレイ開始時に天気（晴れ・雨・曇り）がランダムに決定され、それぞれ異なる演出が適用されます。
シェーダーが使用できないヘッドレス環境では Sprite フォールバックで安全に動作します。

## 変更内容

- **天気システム** (`WeatherState`: Sunny / Rainy / Cloudy) — セッション開始時にランダム決定
- **ShadersPlugin** — `assets/shaders/` の WGSL ファイルを `Material2d` として登録
  - `SoftCircleMaterial` — 水滴パーティクル用 SDF 円
  - `RadialGradientMaterial` — 合体フラッシュ用放射グラデーション
  - `ScreenDropletMaterial` — カメラレンズ水滴用ホローリング
  - `WeatherPostprocessMaterial` — 天気別フルスクリーンカラーオーバーレイ
  - `RainDropMaterial` — 中央グローつきソフトストリーク雨粒
  - `SunMaterial` — 回転するライトレイ付き太陽ディスク（晴れ）
  - `CloudMaterial` — SDF smooth-union による流れる雲（曇り）
- **雨演出の改善** — 雨粒サイズ拡大、風向き統一、ドロップごとのアルファ差異
- **太陽演出** — 晴れ時に右上へ黄金色のグロー太陽をスポーン、光線が毎フレーム回転
- **雲演出** — 曇り時に 8 個の雲パフが右→左へ流れ、端でアルファフェード
- **Bloom** — 晴れ時のみカメラに Bloom コンポーネントを付与

## テスト

- [x] ユニットテスト追加（sun, cloud_effect, postprocess, rain, weather 等）
- [x] `cargo test --workspace` — 291 テスト全通過
- [x] `cargo clippy -- -D warnings` — 警告ゼロ
- [x] ゲーム内で各天気の演出を目視確認

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic weather system with three states (Sunny, Rainy, Cloudy) that change appearance each session
  * Introduced weather-dependent visual effects including rain particles, screen droplets, floating clouds, and an animated sun with bloom lighting
  * Implemented weather overlay that adjusts the visual atmosphere based on current weather conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->