### PR TITLE
fix(audio): apply saved BGM/SFX volume on startup and new sound playback

### DIFF
--- a/app/audio/src/bgm.rs
+++ b/app/audio/src/bgm.rs
@@ -22,8 +22,9 @@ use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use std::time::Duration;
 use suika_game_core::prelude::AppState;
+use suika_game_core::resources::settings::SettingsResource;
 
-use crate::channels::BgmChannel;
+use crate::channels::{BgmChannel, volume_to_db};
 use crate::config::{AudioConfig, AudioConfigHandle};
 use crate::handles::BgmHandles;
 
@@ -108,6 +109,7 @@ pub fn switch_bgm_on_state_change(
     bgm_handles: Option<Res<BgmHandles>>,
     audio_config_handle: Option<Res<AudioConfigHandle>>,
     audio_config_assets: Res<Assets<AudioConfig>>,
+    settings: Res<SettingsResource>,
 ) {
     let Some(bgm_handles) = bgm_handles else {
         return;
@@ -134,8 +136,10 @@ pub fn switch_bgm_on_state_change(
             cfg.bgm_fade_out_secs,
         )));
 
-    // Start the new track.  Per-sound volumes are design levels from AudioConfig;
-    // the overall user volume is applied separately via AudioChannel::set_volume.
+    // Start the new track.  Combine the designer's dB offset (from AudioConfig)
+    // with the user's channel volume (from SettingsResource) so that the saved
+    // volume preference is always applied — even on the very first BGM start.
+    let user_bgm_db = volume_to_db(settings.bgm_volume);
     match desired {
         BgmTrack::None => {
             // Already stopped above; nothing more to do.
@@ -144,7 +148,7 @@ pub fn switch_bgm_on_state_change(
             bgm_channel
                 .play(bgm_handles.title.clone())
                 .looped()
-                .with_volume(cfg.bgm_title_volume)
+                .with_volume(cfg.bgm_title_volume + user_bgm_db)
                 .fade_in(AudioTween::linear(Duration::from_secs_f32(
                     cfg.bgm_title_fade_in_secs,
                 )));
@@ -153,7 +157,7 @@ pub fn switch_bgm_on_state_change(
             bgm_channel
                 .play(bgm_handles.game.clone())
                 .looped()
-                .with_volume(cfg.bgm_game_volume)
+                .with_volume(cfg.bgm_game_volume + user_bgm_db)
                 .fade_in(AudioTween::linear(Duration::from_secs_f32(
                     cfg.bgm_game_fade_in_secs,
                 )));
@@ -162,7 +166,7 @@ pub fn switch_bgm_on_state_change(
             // One-shot: no loop, no fade-in.
             bgm_channel
                 .play(bgm_handles.gameover.clone())
-                .with_volume(cfg.bgm_gameover_volume);
+                .with_volume(cfg.bgm_gameover_volume + user_bgm_db);
         }
     }
 

--- a/app/audio/src/channels.rs
+++ b/app/audio/src/channels.rs
@@ -22,6 +22,9 @@ use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use suika_game_core::resources::settings::SettingsResource;
 
+use crate::bgm::{BgmTrack, CurrentBgm};
+use crate::config::{AudioConfig, AudioConfigHandle};
+
 // ---------------------------------------------------------------------------
 // Channel marker types
 // ---------------------------------------------------------------------------
@@ -110,9 +113,26 @@ pub fn apply_volume_settings(
     bgm_channel: Res<AudioChannel<BgmChannel>>,
     sfx_channel: Res<AudioChannel<SfxChannel>>,
     mut prev: ResMut<PreviousVolume>,
+    current_bgm: Res<CurrentBgm>,
+    audio_config_handle: Option<Res<AudioConfigHandle>>,
+    audio_config_assets: Res<Assets<AudioConfig>>,
 ) {
     if settings.bgm_volume != prev.bgm {
-        bgm_channel.set_volume(volume_to_db(settings.bgm_volume));
+        // Combine design dB (track-specific offset from AudioConfig) with the
+        // user's volume preference so that already-playing BGM stays consistent
+        // with the volume used when the track was started.
+        let default_cfg = AudioConfig::default();
+        let cfg = audio_config_handle
+            .as_ref()
+            .and_then(|h| audio_config_assets.get(&h.0))
+            .unwrap_or(&default_cfg);
+        let design_db = match current_bgm.track {
+            BgmTrack::Title => cfg.bgm_title_volume,
+            BgmTrack::Game => cfg.bgm_game_volume,
+            BgmTrack::GameOver => cfg.bgm_gameover_volume,
+            BgmTrack::None => 0.0,
+        };
+        bgm_channel.set_volume(design_db + volume_to_db(settings.bgm_volume));
         prev.bgm = settings.bgm_volume;
     }
     if settings.sfx_volume != prev.sfx {

--- a/app/audio/src/channels.rs
+++ b/app/audio/src/channels.rs
@@ -1,22 +1,31 @@
 //! Typed audio channels for BGM and SFX.
 //!
-//! Using two separate [`AudioChannel`] buses means the user's volume slider
-//! controls **all** sounds on that bus at once, independently of the
-//! per-sound design volumes set in `assets/config/audio.ron`.
+//! Using two separate [`AudioChannel`] buses lets BGM and SFX be controlled
+//! independently.  Because `bevy_kira_audio`'s `.with_volume(design_dB)`
+//! overrides the channel-level volume for **new** sounds, user preference and
+//! design offset are combined at the call site rather than applied separately.
 //!
-//! # Architecture
+//! # Effective-volume model
 //!
 //! ```text
-//! AudioChannel<BgmChannel>  ← set_volume(user_bgm_dB)
-//!   └─ bgm_handles.title / game / gameover   ← with_volume(design_dB)
-//!
-//! AudioChannel<SfxChannel>  ← set_volume(user_sfx_dB)
-//!   └─ sfx_handles.*                         ← with_volume(design_dB)
+//! effective_dB = design_dB (AudioConfig)  +  user_dB (SettingsResource)
 //! ```
 //!
-//! When the user sets volume to 0 the channel is driven to −100 dB, which
-//! bevy_kira_audio / kira rounds to silence, guaranteeing no audio leaks
-//! through regardless of the per-sound design levels.
+//! This combined value is passed to `.with_volume(effective_dB)` each time a
+//! sound is started, and to `AudioChannel::set_volume(effective_dB)` when the
+//! user adjusts the slider (so already-playing BGM updates immediately).
+//!
+//! ```text
+//! AudioChannel<BgmChannel>
+//!   └─ bgm_handles.*  ← .with_volume(design_dB + user_bgm_dB)   at track start
+//!                     ← set_volume(design_dB + user_bgm_dB)      on settings change
+//!
+//! AudioChannel<SfxChannel>
+//!   └─ sfx_handles.*  ← .with_volume(design_dB + user_sfx_dB)   at each SFX play
+//! ```
+//!
+//! When the user sets volume to 0 the user_dB term is −100 dB, which
+//! bevy_kira_audio / kira rounds to silence regardless of the design offset.
 
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;

--- a/app/audio/src/sfx/game.rs
+++ b/app/audio/src/sfx/game.rs
@@ -3,9 +3,10 @@
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use suika_game_core::events::{FruitMergeEvent, ScoreEarnedEvent};
+use suika_game_core::resources::settings::SettingsResource;
 
 use super::MergeSfxCategory;
-use crate::channels::SfxChannel;
+use crate::channels::{SfxChannel, volume_to_db};
 use crate::config::{AudioConfig, AudioConfigHandle};
 use crate::handles::SfxHandles;
 
@@ -25,6 +26,7 @@ pub fn play_merge_sfx(
     sfx_handles: Option<Res<SfxHandles>>,
     audio_config_handle: Option<Res<AudioConfigHandle>>,
     audio_config_assets: Res<Assets<AudioConfig>>,
+    settings: Res<SettingsResource>,
 ) {
     let Some(sfx_handles) = sfx_handles else {
         return;
@@ -37,31 +39,32 @@ pub fn play_merge_sfx(
         .and_then(|h| audio_config_assets.get(&h.0))
         .unwrap_or(&default_cfg);
 
+    let user_sfx_db = volume_to_db(settings.sfx_volume);
     for event in merge_events.read() {
         match MergeSfxCategory::from_fruit(event.fruit_type) {
             MergeSfxCategory::Small => {
                 sfx_channel
                     .play(sfx_handles.merge_small.clone())
-                    .with_volume(cfg.sfx_merge_small_volume)
+                    .with_volume(cfg.sfx_merge_small_volume + user_sfx_db)
                     .with_playback_rate(cfg.sfx_merge_small_pitch);
             }
             MergeSfxCategory::Medium => {
                 sfx_channel
                     .play(sfx_handles.merge_medium.clone())
-                    .with_volume(cfg.sfx_merge_medium_volume)
+                    .with_volume(cfg.sfx_merge_medium_volume + user_sfx_db)
                     .with_playback_rate(cfg.sfx_merge_medium_pitch);
             }
             MergeSfxCategory::Large => {
                 sfx_channel
                     .play(sfx_handles.merge_large.clone())
-                    .with_volume(cfg.sfx_merge_large_volume)
+                    .with_volume(cfg.sfx_merge_large_volume + user_sfx_db)
                     .with_playback_rate(cfg.sfx_merge_large_pitch);
             }
             MergeSfxCategory::Watermelon => {
                 // Special fanfare — no pitch shift, played at full original pitch.
                 sfx_channel
                     .play(sfx_handles.watermelon.clone())
-                    .with_volume(cfg.sfx_watermelon_volume);
+                    .with_volume(cfg.sfx_watermelon_volume + user_sfx_db);
                 info!("Watermelon! Playing fanfare SFX");
             }
         }
@@ -85,6 +88,7 @@ pub fn play_combo_sfx(
     sfx_handles: Option<Res<SfxHandles>>,
     audio_config_handle: Option<Res<AudioConfigHandle>>,
     audio_config_assets: Res<Assets<AudioConfig>>,
+    settings: Res<SettingsResource>,
 ) {
     let Some(sfx_handles) = sfx_handles else {
         return;
@@ -96,6 +100,7 @@ pub fn play_combo_sfx(
         .and_then(|h| audio_config_assets.get(&h.0))
         .unwrap_or(&default_cfg);
 
+    let user_sfx_db = volume_to_db(settings.sfx_volume);
     for event in score_events.read() {
         // Only play the combo sound when a real combo is in progress.
         if event.combo_count < 2 {
@@ -109,7 +114,7 @@ pub fn play_combo_sfx(
 
         sfx_channel
             .play(sfx_handles.combo.clone())
-            .with_volume(cfg.sfx_combo_volume)
+            .with_volume(cfg.sfx_combo_volume + user_sfx_db)
             .with_playback_rate(pitch);
     }
 }
@@ -124,6 +129,7 @@ pub fn play_gameover_sfx(
     sfx_handles: Option<Res<SfxHandles>>,
     audio_config_handle: Option<Res<AudioConfigHandle>>,
     audio_config_assets: Res<Assets<AudioConfig>>,
+    settings: Res<SettingsResource>,
 ) {
     let Some(sfx_handles) = sfx_handles else {
         return;
@@ -137,7 +143,7 @@ pub fn play_gameover_sfx(
 
     sfx_channel
         .play(sfx_handles.gameover.clone())
-        .with_volume(cfg.sfx_gameover_volume);
+        .with_volume(cfg.sfx_gameover_volume + volume_to_db(settings.sfx_volume));
 
     info!("Game-over SFX playing");
 }

--- a/app/audio/src/sfx/ui.rs
+++ b/app/audio/src/sfx/ui.rs
@@ -2,9 +2,10 @@
 
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
+use suika_game_core::resources::settings::SettingsResource;
 use suika_game_ui::components::{KeyboardFocusIndex, MenuButton};
 
-use crate::channels::SfxChannel;
+use crate::channels::{SfxChannel, volume_to_db};
 use crate::config::{AudioConfig, AudioConfigHandle};
 use crate::handles::SfxHandles;
 
@@ -21,6 +22,7 @@ pub fn play_ui_sfx(
     sfx_handles: Option<Res<SfxHandles>>,
     audio_config_handle: Option<Res<AudioConfigHandle>>,
     audio_config_assets: Res<Assets<AudioConfig>>,
+    settings: Res<SettingsResource>,
 ) {
     let Some(sfx_handles) = sfx_handles else {
         return;
@@ -32,17 +34,18 @@ pub fn play_ui_sfx(
         .and_then(|h| audio_config_assets.get(&h.0))
         .unwrap_or(&default_cfg);
 
+    let user_sfx_db = volume_to_db(settings.sfx_volume);
     for interaction in interaction_query.iter() {
         match *interaction {
             Interaction::Pressed => {
                 sfx_channel
                     .play(sfx_handles.button_click.clone())
-                    .with_volume(cfg.sfx_button_click_volume);
+                    .with_volume(cfg.sfx_button_click_volume + user_sfx_db);
             }
             Interaction::Hovered => {
                 sfx_channel
                     .play(sfx_handles.button_hover.clone())
-                    .with_volume(cfg.sfx_button_hover_volume);
+                    .with_volume(cfg.sfx_button_hover_volume + user_sfx_db);
             }
             Interaction::None => {}
         }
@@ -68,6 +71,7 @@ pub fn play_keyboard_ui_sfx(
     sfx_handles: Option<Res<SfxHandles>>,
     audio_config_handle: Option<Res<AudioConfigHandle>>,
     audio_config_assets: Res<Assets<AudioConfig>>,
+    settings: Res<SettingsResource>,
 ) {
     // No menu buttons on screen — reset tracking and bail.
     if button_query.is_empty() {
@@ -88,19 +92,21 @@ pub fn play_keyboard_ui_sfx(
         .and_then(|h| audio_config_assets.get(&h.0))
         .unwrap_or(&default_cfg);
 
+    let user_sfx_db = volume_to_db(settings.sfx_volume);
+
     // Hover sound: only when the focus index actually moved.
     let old = prev_focus.replace(current);
     if old.is_some_and(|p| p != current) {
         sfx_channel
             .play(sfx_handles.button_hover.clone())
-            .with_volume(cfg.sfx_button_hover_volume);
+            .with_volume(cfg.sfx_button_hover_volume + user_sfx_db);
     }
 
     // Confirm key → click sound.
     if keyboard.just_pressed(KeyCode::Enter) {
         sfx_channel
             .play(sfx_handles.button_click.clone())
-            .with_volume(cfg.sfx_button_click_volume);
+            .with_volume(cfg.sfx_button_click_volume + user_sfx_db);
     }
 }
 


### PR DESCRIPTION
## 概要

`save/settings.json` に保存されたBGM・SFX音量がゲーム起動時および各サウンド再生時に適用されない問題を修正する。

`bevy_kira_audio` の仕様として `AudioChannel::set_volume()` で設定したチャンネル音量は、`.with_volume(design_dB)` 付きで新規サウンドを再生すると `PartialSoundSettings::apply()` によって上書きされる。このため、ユーザーが保存した音量が常に無視されていた。

## 変更内容

- `bgm.rs`: `switch_bgm_on_state_change` に `SettingsResource` を追加し、`.with_volume(design_dB + user_dB)` で設計音量とユーザー音量を合算
- `channels.rs`: `apply_volume_settings` に `CurrentBgm` と `AudioConfig` を追加し、再生中BGMにも合算音量を適用
- `sfx/game.rs`: 全SFX再生関数（merge・combo・gameover）に `SettingsResource` を追加し音量を合算
- `sfx/ui.rs`: UIボタン音（hover・click）にも同様の修正を適用

## テスト

- [x] ユニットテスト 39件全通過
- [x] ゲーム内でBGM・SFX音量の動作確認
- [x] `just clippy` / `just test` 実行済み

Closes #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BGM volume now combines per-track designer calibration with the user’s BGM setting for consistent levels across Title, Game, and Game Over.
  * In-game SFX volumes now combine configured base levels with the user’s SFX setting for accurate playback.
  * UI and keyboard-triggered SFX now respect configured per-effect levels plus the user’s SFX preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->